### PR TITLE
Fix jax update errors

### DIFF
--- a/docs/tutorials/jax_backend_demo.ipynb
+++ b/docs/tutorials/jax_backend_demo.ipynb
@@ -3,6 +3,8 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from matplotlib import pyplot as plt\n",
     "import numpy as np\n",
@@ -10,22 +12,22 @@
     "from qiskit_dynamics import solve_lmde\n",
     "from qiskit_dynamics.signals import Signal\n",
     "from qiskit_dynamics.models import HamiltonianModel"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# In this demo\n",
     "\n",
     "We show how `qiskit_dynamics` can be used with the `jax` backend to perform transformations like just-in-time compiling and gradient computation."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from qiskit_dynamics import dispatch\n",
     "from qiskit_dynamics.dispatch import Array\n",
@@ -42,13 +44,16 @@
     "def gaussian(amp, sig, t0, t):\n",
     "    # Note: to enforce using the jax backend for the computation of the gaussian, wrap the\n",
     "    # input to the numpy function in an Array\n",
-    "    return amp * np.exp( -Array((t - t0)**2 / (2 * sig**2)))"
-   ],
-   "outputs": [],
-   "metadata": {}
+    "    amp = Array(amp)\n",
+    "    sig = Array(sig)\n",
+    "    t0 = Array(t0)\n",
+    "    t = Array(t)\n",
+    "    return amp * np.exp( -(t - t0)**2 / (2 * sig**2))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# 1. `jit`: Just-in-time compiling a parameterized simulation\n",
     "\n",
@@ -57,12 +62,21 @@
     "- Simulating a system over a range of model parameters\n",
     "\n",
     "One way to do this is the following. First, construct a model with just operators."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
+     ]
+    }
+   ],
    "source": [
     "#####################\n",
     "# construct operators\n",
@@ -81,20 +95,11 @@
     "#####################################\n",
     "\n",
     "hamiltonian = HamiltonianModel(operators=operators)"
-   ],
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": [
-      "WARNING:absl:No GPU/TPU found, falling back to CPU. (Set TF_CPP_MIN_LOG_LEVEL=0 and rerun for more info.)\n"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Next, define a function which takes the simulation input parameters and outputs the results. In this case, we parameterize a gaussian drive pulse, set it into the model, then solve and return the results.\n",
     "\n",
@@ -103,12 +108,13 @@
     "\n",
     "Additional note:\n",
     "- The `solve` function will automatically use the `scipy` solver. To make the full function jax compatible, we must specify a jax solver. Here `jax_odeint` is the equivalent of the `DOP853` algorithm in `scipy`."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def sim_function(amp, sig):\n",
     "    \n",
@@ -135,119 +141,130 @@
     "amp = 1.\n",
     "sig = 0.399128/r\n",
     "    "
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Next, compile the function by calling `jax.jit`."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "fast_sim = jit(sim_function)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Run the simulation once.\n",
     "\n",
     "Note: the function is only compiled when it is called for the first time. Hence, the first call is slower due to this overhead."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "source": [
-    "%time fast_sim(2*amp, 2*sig).block_until_ready()"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "CPU times: user 754 ms, sys: 10.8 ms, total: 765 ms\n",
-      "Wall time: 759 ms\n"
+      "CPU times: user 670 ms, sys: 11.5 ms, total: 681 ms\n",
+      "Wall time: 677 ms\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Array([-0.01469478-0.02316957j, -0.87381816-0.48547816j])"
       ]
      },
+     "execution_count": 6,
      "metadata": {},
-     "execution_count": 6
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "%time fast_sim(2*amp, 2*sig).block_until_ready()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Call a second time:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "source": [
-    "%time fast_sim(amp, sig).block_until_ready()"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "CPU times: user 1.31 ms, sys: 1.27 ms, total: 2.59 ms\n",
-      "Wall time: 937 µs\n"
+      "CPU times: user 879 µs, sys: 226 µs, total: 1.11 ms\n",
+      "Wall time: 539 µs\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Array([0.96087419-0.27193942j, 0.0511707 +0.01230027j])"
       ]
      },
+     "execution_count": 7,
      "metadata": {},
-     "execution_count": 7
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "%time fast_sim(amp, sig).block_until_ready()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "For speed comparison, the same simulation using the `numpy` backend and the corresponding `scipy` solver takes about `200ms`. Hence, the compiled simulation is almost 2 orders of magnitude faster."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# 2. Automatic differentiation\n",
     "\n",
     "In addition to compilation, `jax` has a variety of function transformations for taking derivatives of functions. The most basic such function is `jax.grad`, which transforms a real scalar-valued function into one that computes its gradient.\n",
     "\n",
     "To demonstrate this, we modify the simulation function into one that outputs the excited state population (to convert it into something with a real/scalar output)."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Array(0.99723026)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "def excited_state_pop(amp):\n",
     "    yf = sim_function(amp, sig)\n",
@@ -255,114 +272,103 @@
     "    \n",
     "\n",
     "excited_state_pop(amp)"
-   ],
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "Array(0.99723026)"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 8
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Next, take the gradient. Here, we also compile the gradient."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "excited_state_grad = jit(grad(excited_state_pop))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "source": [
-    "%time excited_state_grad(2 * amp).block_until_ready()"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "CPU times: user 2.06 s, sys: 0 ns, total: 2.06 s\n",
-      "Wall time: 2.05 s\n"
+      "CPU times: user 1.61 s, sys: 14.8 ms, total: 1.62 s\n",
+      "Wall time: 1.62 s\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Array(-0.03250497)"
       ]
      },
+     "execution_count": 10,
      "metadata": {},
-     "execution_count": 10
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "%time excited_state_grad(2 * amp).block_until_ready()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "source": [
-    "%time excited_state_grad(amp).block_until_ready()"
-   ],
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "CPU times: user 2.93 ms, sys: 0 ns, total: 2.93 ms\n",
-      "Wall time: 1.71 ms\n"
+      "CPU times: user 1.73 ms, sys: 966 µs, total: 2.7 ms\n",
+      "Wall time: 1.3 ms\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "Array(-0.00128185)"
       ]
      },
+     "execution_count": 11,
      "metadata": {},
-     "execution_count": 11
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {}
+   "source": [
+    "%time excited_state_grad(amp).block_until_ready()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Note: the derivative at the default `amp` value is near $0$ as the parameters used are near a $\\pi$-pulse, and as such near a maximum of the population function."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# 3. State tracking\n",
     "\n",
     "Our wrapper for the `jax` integrators also supports the `t_eval` argument in the style of `scipy`'s `solve_ivp`. We can use this argument to view the state of the solution over an interval.\n",
     "\n",
     "Note: if `t_eval` is included, both `t_span` and `t_eval` will be handled with pure numpy, and so compilation will treat `t_span` as a static parameter."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "def sim_function(amp):\n",
     "    \n",
@@ -385,68 +391,66 @@
     "    results = solve_lmde(ham_copy, y0=np.array([0., 1.], dtype=complex), t_span=[0,T], \n",
     "                         t_eval=np.linspace(0, T, 100), method='jax_odeint', atol=1e-10, rtol=1e-10)\n",
     "    return results.y.data"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "jitted = jit(sim_function)"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABhIklEQVR4nO3dd2CcxZ34//c821dl1SWrWZIt994wmNAJvYUESAiBJPxI7kKSu1xyIcdd6iUhl3xT7tIgCYRQQksAE0wxYDBgjAu4y7JlWb2vyvb2PPP7Y9eyZMtF1kqyrHndbXb32XnmmQfb83memXlmhJQSRVEUZfLSxrsAiqIoyvhSgUBRFGWSU4FAURRlklOBQFEUZZJTgUBRFGWSM493AU5FTk6OLCsrG+9iKIqiTChbt27tklLmHrl9QgaCsrIytmzZMt7FUBRFmVCEEPVDbVdNQ4qiKJOcCgSKoiiTnAoEiqIok5wKBIqiKJOcCgSKoiiTXFICgRDiQSFEhxBi1zF+F0KI/xVC1Aghdgghlgz47XYhxP7E6/ZklEdRFEU5ecm6I/gzcPlxfr8CqEy87gJ+ByCEyAK+A5wFrAC+I4TITFKZFEVRlJOQlOcIpJTrhRBlx0lyHfAXGZ/zeqMQIkMIMQW4AFgrpewGEEKsJR5Q/pqMcimKcmaIGAbdUZ2eaIyeqE5PLIYvZhA0DAK6QdSQGEgMCRIwCTAJgQaYhcCsxT9riW1CgEyklYAuZf+7LuPvhqQ/T4P470fO2i8ECEAg4u/930lsOZpM5EXi2EOmOc7qAHcU5ZBtTe4jYGP1QFkR0Djge1Ni27G2H0UIcRfxuwlKS0tHp5SKoiSNN6bzXq+PLX1+2iMxOiNRemM6ACYEJgFWTWDVNGyaQErQiVfEfl3HGzPwxOKVv1c3xvlsDjtUvY/XSi7X5mVM2EAwYlLKB4AHAJYtW6ZW01GU01BAN3i6rZun27r50BtAl2AWkGu1kGsxk2kxI4hX+DEpCegGvVGdsJRoHL6KTzFrFNoszEyxk2kxkZ3YN8tiJstiwmU2kW424dA0nCYNiyYwIdAStbSeuIqPJa7sYzL+Gei/wu+/iid+p2AS9N9BaCKe16E841f7x7jCT9xNHLpjiH8+fhUlBtwvHCPbY9xPHHv7SIxVIGgGSgZ8L05saybePDRw+5tjVCZFUZLEHYnxx6ZOHm7pojuqMzfVzpdL8zkvM42lLic2bWwHKMYDgsA2BscSYkAj0NEfJoSxCgSrgbuFEE8Q7xjuk1K2CiFeAX40oIP4o8C3xqhMiqKMkF/X+UNjJ79u6MCvG3w0J50vluSx0pVyzCto5fSTlEAghPgr8Sv7HCFEE/GRQBYAKeXvgTXAlUANEAA+m/itWwjxA2BzIqvvH+o4VhTl9OXXdR5v6eb/GtrpiMS4IsfFPRVTmJliH++iKacgWaOGPnmC3yXwpWP89iDwYDLKoSjK6GoKRXi81c1DTV30xHTOzkjhwXnlLHOljHfRksYwIuh6CMMIousBdD1ATA9g6EF0I4ihhzCMMIYRwZBRpIwhDR0pYwzdO3DEFnmoFyHRsyATY5KkRGIc/o5ESoP+sU2JbMrK78ZmzUnqOU+YzmJFUUZPXzTGWreHzkgMTYCGwEASNeKdrAeCYTb2+mkMRQC4PCedu0vzT4sAoOtB/IEDBAIHCQQOEg61Eol2E412E4t5MYwoUkaRRqx/nyMrWimjh9NJfQxLLxDCRP+AU6EhhDbg++HBqIe+l5TcDioQKIqSLC919vJYazdvdXuJHmfwepbFxNkZqXyhJJcLs9KY5hyfJiApDfyBA3j6PqTPsx2PZwd+f/WAyltgteZitWZhsWTidOaiaVY0YUGII6o7ocXH7ggNIcxomgVNWNBMDkyaA81kx2xKwWRyoJmcmBLbTSYHmmZDCAuaZkUIc+J1qBKPl+OIgw3+dpr1n6hAoCiT1J+aOrl3fzNFNgt3FudwTV4GM5x2DOIPVJkSQyotQmARYkwrL8OIEIl0EYl04ffX4PPtxeerxuPdQSzmAcBsTic9fSE5OV8kNXU2Kc4KHI6pmEyqn2K4VCBQlEno0RY39+5v5vKcdP4wtxyLNvqVfDDYRGfnqwSCBwkG6gmGmjCMSKJNXEdKAyl1pNTRdd+gfTXNSoqzkry8K3C5luBKX4LTWX7aXVlPVCoQKMok83RbN9+obuSirDTun1s2qkHAMGJ0dr5MS8tTdPdsACRmcwZO51TS0uZh0uzxNnKhIYQp0bxixmJ2YbXmYLXm4HSW43CUoWmquhot6r+sokwiBwIh/nVvA6syUvnTvPJRfdDL7z/Anqpv4PFsx24vorz8q0wp+BgOx5CzyCjjSAUCRZlEflTbik3T+N3cqThMoxMEpDRobHqYAwd+iqY5mDvnF+TnXz2gI1U53ahAoCiTxNY+Py929vH1sgJyrZZROYauh9i951/p7HyVnOyLmDXrR9hsuaNyLCV5VCBQlElASskPDrSQazXzTyWjUzFHIt3s2HEXfZ5tVE6/l5KSz6rO3AlCBQJFmQTWuj1s7PNz34xiUsympOcfDDbw4bbPEg63Mn/er8nLO946VcrpRgUCRTnD6VLyw9pWKhw2bp2SnfT8+zzb2b79TqQ0WLzoL2RkLEv6MZTRpXpvFOUM97rbQ7U/xL+XFyR9qGhn52t88MGnMJlSWLb0aRUEJih1R6AoZ7gHm7qYYrNwVW5G0vI0jCgNDX/gQO0vSE+bx4KFf0j6RGjK2FGBQFHOYDWBEG/2eLkniXcDHs9Oqvb+Bz7fHvLyrmTO7J9gMjmTkrcyPlQgUJQz2ENNXViF4NbCkfUNhMOddHe/TZf7TTo6XsJqzWH+vN+Sl3dZkkqqjKdkLUxzOfArwAT8UUp53xG//wK4MPHVCeRJKTMSv+nAzsRvDVLKa5NRJkWZ7HwxnSfburk2L+OEzw0YRoyW1qfweHYQiXQQDncQi/kS0zNHiEbj60VZLNkUF3+aivJ/xWJJH4vTUMbAiAOBiE+m/RvgUqAJ2CyEWC2l3HMojZTyXwek/zKweEAWQSnlopGWQ1GUwZ5u78GnG3yu6Pht9x7PTvbuvRevbzdWay42Wz522xTMKekIzYImzNjtRWRnn0dq6uxJ+4SwlJJoNEooFCISifS/YrEYuq6j6zqGYcQXsz/OlN6Hfj/Wa2AeQ72WL1+O05ncprhk3BGsAGqklLUAiXWJrwP2HCP9J4kvZakoyiiRUvJgUycL0xwsTh+60pBSUlv7c+rqf4/Vms28eb8mL/fyM+IhsGg0Sk9PD16vl3A4TCQSIRqNDqpQ4XClfKgyj0ajRCIRQqEQ4XCYYDDY/wqFQhiGMc5nBnPmzDktA0ER0DjgexPxBeqPIoSYCpQDbwzYbBdCbAFiwH1SyueOse9dwF0ApaWlIy+1opzB1vf42B8I86tZpces2Ds6XqSu/rcUFNzAjMpvT9imnlgsRmtrK/X19dTX19PW1obX6z2lvMxmMzabrf/lcDhwuVzY7XYcDgd2ux273Y7NZsNqtWKxWDCbzZhMJkwmE5qmIYZYu2Go70O9Bu5/vDTJNtadxbcAz8jBa8FNlVI2CyEqgDeEEDullAeO3FFK+QDwAMCyZcuOfd+lKAoPNHaSYzFzfX7GkL+HI11U7/su6ekLmT3rvgk3xXM4HKampoaqqir2799POBwGICcnh4qKCrKyssjKyiI9PX1QpX1kpQrxSvlQZX4m3A2dimT86TcDJQO+Fye2DeUWjljEXkrZnHivFUK8Sbz/4KhAoCjKydnvD/F6t4evlxUMOc20lJLq6m8Ti/mZPfsnEyYI+Hw+9u3bR1VVFbW1tei6jtPpZM6cOVRWVlJaWkpqaup4F3NCSsbfgM1ApRCinHgAuAX41JGJhBCzgEzgvQHbMoGAlDIshMgBVgH/k4QyKcqk9YemTmya4PaioYeMtnf8g87OV5g+7d9JTakc49IdzTAMYrEYhmH0v/x+Px6Ph76+Ppqbm2loaMDtdgPgcrlYvnw5s2bNorS0dFSaSiabEQcCKWVMCHE38Arx4aMPSil3CyG+D2yRUq5OJL0FeEIO7k6fDdwvhDCIT3dx38DRRoqiDE93NMbTbd18LD9zyCGjsZifffu+R3r6IkpL7xzTskkpaWpqor6+noaGBlpaWgiFQsRisePuZ7fbKS0tZfHixUybNo2CgoJJ24QzWpJyTyilXAOsOWLbt4/4/t0h9tsAzE9GGRRFgcda3AQNyV3FQ0813db2LNFoDwsXPBBfInKMNDc388orr9DQ0ABAdnY206dPx+l0YrFYsFgsaJrW/3I6naSnp/e/1FX/6JoYjYOKopxQ1JA82NzFeZmpzE51HPW7lJLGpkdIS5tHevriIXJIvkAgwCuvvML27dtxOp1cddVVzJkzh5SUlDE5vnJyVCBQlDPEg82dtIaj/GxmyZC/9/RsIBCoYc7s/xmTppW+vj4effRR3G43q1at4iMf+Qh2u33Uj6sMnwoEinIGqA+Gua+2jUuy07koK23INI1Nf8FiySIv7+pRL09XVxePPPIIwWCQ2267jfLy8lE/pnLqVCBQlAlOSsk3qhsxCfjJjOIhr/aDwUa6ul6nbOoXMZlso1qe1tZWHnnkEQDuuOMOCgsLR/V4ysipQKAoE9wTbd2s7/Fx34xiiuzWIdM0NT+KEBpFRbeOall6enp49NFHMZvN3H777WRnJ39FNCX5VFe8okxge/1BvlvTwkpXCp85xlTTuh6ipeVpcnMvw26fMmpl8fv9PPLII+i6zm233aaCwASi7ggUZQLyxHT+38E2/tTcSZrJxM9mlaAdowO4s2stsVgfRYWfHLXyRCIRHnvsMTweD5/5zGfIzR16+KpyelKBQFFOc02hCM+197DF4ydsSKKGZK8/hDsa49Yp2dxTMYUc67H/Kbe1PYfNVkBm5spRKV8sFuPJJ5+ktbWVm2++WU0KOQGpQKAop6ltngDfrWlmY58fgEqnjVSTCYsmWO5K4atT81l0jCmmDwlHuujufpvSkjtHZR0BXdd5+umnOXDgANdddx2zZs1K+jGU0acCgaKchkK6wRf31BHQDe4pL+CG/EymOoY/2qe9/QWk1CkouD7pZTQMg7///e9UV1dz5ZVXsnjx2DykpiSfCgSKchr6fWMHdcEITyys4IKsU18noK3tOdJS55KaOiOJpYt3DK9evZrq6mouvfRSVqxYkdT8lbGlAoGinGYaQxF+Vd/OVbmuEQUBv78Gr3cXldPvTWLp4MCBAzz77LMEg0GuuOIKzjpryHWolAlEBQJFOc18tya+nMf3pheNKJ/WtucAjfz8a0ZcJq/XS01NTf96ADk5Odx6661MmTJ6w1GVsaMCgaKcRt7q9vJiZx/3lBdQfIyHw06GlAbtbc+TnXUuNtvJDeVsaWmhtraWzs5OOjs7CQQC/YuyBwIBAFJTUznnnHO44IILsFpPvXzK6UUFAkU5jfyhqZMim4UvluSNKJ+envcIhVuYNu0bJ0wrpeSdd97hjTfeQEpJamoqeXl55OTk9K/F63K5qKysJD8/X60FcAZSgUBRThMh3eDdHi+fmpKN3TSyoZ5NzY9jsWSSm3vZ8Y8ZCvHcc8+xd+9e5s6dy5VXXqmmiJ6EkjKwWAhxuRCiWghRI4S4Z4jf7xBCdAohtiVedw747XYhxP7E6/ZklEdRJqKNfT6ChuSi7FPvIAYIh9vp6lrLlCk3HneCuVgsxkMPPUR1dTUf/ehH+fjHP66CwCQ14jsCEV/m6DfApUATsFkIsXqIJSeflFLefcS+WcB3gGWABLYm9u0ZabkUZaJ5w+3FpgnOzhjZAuwtLU8hpX7CKSXee+892tvbufnmm5k9e/aIjqlMbMloGloB1EgpawGEEE8A1wEns/bwZcBaKWV3Yt+1wOXAX5NQLkWZUN7o9nBORirOETQLGUaM5pYnyMr6CE5n2THT9fX1sX79embNmqWCwAhJKUGXyJgBhkRKwBiwNLs8ao94GinBiL/37yMl0jj0mwSZyP9QegmWolQ0a3KXGU1GICgCGgd8bwKGGlh8oxDiPGAf8K9SysZj7DvkmDkhxF3AXYCay0Q549QHw9QEwtxemDOifNzuNwmH25gx49vHTbd27VqklFx22fH7EM4U8lDFahyqWA9VrsQr31i8IpdRHSOkY4RiyGAMwx9FD8TfjUAUIxDDCMbiv4fjaYkZY3ou+V9bipZ3/KlFhmusOotfAP4qpQwLIb4APAxcNJwMpJQPAA8ALFu27KgYqygT2RvdXgAuyh56dbGT1dz8GDZrPjnZFx8zTV1dHbt27eL8888nMzNzRMc7nUhDEm31E2nyEmsPEO0IoPeGMULxyhv9FKsNAZrDjOa0oDnNmFItmHMcaHYTwmZCWEwIs0CYNDCJ+KgqAQwcXXXEQKvDaRLpNBFPrgkQAz5r8XQD05sykr+wUDICQTMwcJHU4sS2flJK94CvfwT+Z8C+Fxyx75tJKJOiTCjr3B6m2q1UnMJ8QocEAgdxd79NedmX0bSh/2kbhsFLL72Ey+Vi1apVp3ys04UR0QlVuQlWdRPe34vhjwIgrBrmPCeWwpR4JW43I6ymeIWrEa98BcRrWRAWDWGOvzS7CZHYR3Oa0RwWhOnMHjKbjECwGagUQpQTr9hvAT41MIEQYoqUsjXx9VqgKvH5FeBHQohDlyUfBb6VhDIpyoQRNgze6fVxc0HWKY/Rl1Kyd+9/YjKlUFT0qWOmO3jwIO3t7dxwww0T9oEwGTMI7e8hsL2T0G43MmqgpVqwz8jEVpmBrdyFyWVDaGd25Z1MIw4EUsqYEOJu4pW6CXhQSrlbCPF9YIuUcjXwFSHEtUAM6AbuSOzbLYT4AfFgAvD9Qx3HijJZvN/rJ6AbXHiMRedPRkvrU/T0bmTWzP8+7pPEW7duxeFwMHfu3FM+1ngwwjqRuj6Cu9wEdnUhgzE0pxnnkjycC/OwlqWrin8EktJHIKVcA6w5Ytu3B3z+Fse40pdSPgg8mIxyKMpE9Hq3B6sQrMo8tWGj4XA7NTU/JiPjLAoLbz5mOp/Px969eznrrLMwm8f/WVIZNeLt92EdGdaRuhHvvNUluj+C3hdB7w0TafAQafKBIRFWE4652TgW5mKfnoEwq9V2k2H8/zYoyiS3qdfPUpeTFNPwhwRKKamu/g6GEWH2rB8dd/GZbdu2YRgGS5cuHUlxT5mUkki9h9C+HsL7e4k0eYcYWnkEs4a1MIW084qxVbiwlqUnfeikogKBooyriGGwxx/kc0XDHzYaDDZwoPbndHatZfq0fz/ucwOGYbB161amTp1KTs7Ihqieipg7SM9zNYT394IAa0kaaReUYEq3IuxmNKsGJq1/tIyWasXssiIcZjW30RhQgUBRxlG1P0TYkCxMO/648Gi0j96+LRh6CMMI4/HsoLnlCYQwUTb1nykp+fxx9z948CA9PT1ceOGFySz+CUld4l3fhOf1BoRJ4LqmgpQl+WgOVfWcTtSfhqKMo+3eIMAx1x4OBptpbHqIlpYn0fVA/3YhTBROuYny8i9js+Wf8DiHOonH8iliGTNw/3Uvod1uHPNzyLimAlN68sfAKyOnAoGijKMd3gAus4mpQ6w90NzyJNXV/wUI8vOvpnDKzVismZg0G2azC4vFdVLH8Pv97N27lxUrVmCxWJJ8BkOTMQP3o1WE9nbjuqaCtFUjW2RHGV0qECjKONrmDbAgzXFUO3gk0k1NzY9xuZYyd87/w24vPOVj7N69G8MwxmxxeRnV6XqkivC+HjKun07qSrWK2elOjb1SlHESNgyqfKEh+wcO1v0vuh5g5szvjygIAOzYsYP8/Hzy80/chDRS0pC4n6gmvL+HzBsrVRCYIFQgUJRxUuULEZVHdxT7/bU0N/+VwsKbSU2pHNExuru7aWpqYv78+SPK52T1rTlIaLcb11UVpCwvGJNjKiOnAoGijJMd3njn74I0x6DtNQd+gqbZqSj/6siPsWMHwJgEAt+GFnzvNJN6TiFp56o+gYlEBQJFGSfbvQEyzSZKB3QU9/RspKvrNcqmfhGrdWTj/aWU7Ny5k7KyMlyuk+tYPlXB3W56XziAfU42rqsrRvVYSvKpQKAo42S7N8jCNOegjuKGxoewWvMoKfnsiPNvaWnB7XazYMGCEed1PKH9Pbgfr8JanEbWLTPVnD8TkAoEijIOQrrBXn+QhQOeHzCMMD09G8jNvRSTyT7iY+zYsQOTyTSqzw6ED/bh/sseLHlOcj47V03/MEGpQKAo42CPP0hMDu4f6O3dgq4HyMm+YMT567rOrl27mDFjBg6H48Q7nIJwvYeuP+/GlGEj5/Pz0Jxj84yCknzqOQJFGQeHnigeOGKoy/0mmmYlM3PliPPfv38/fr9/VJqFpG7geaMR77oGTJl2cu6cjyl1Yq5toMSpQKAo42C7J0C2xUyR7fBVtNv9JhkZZ2EyjXw92k2bNpGens6MGTNGnNchMmoQru+j76U6os0+nEvyyLh2GppdVSMTnfoTVJRxsOOIJ4qDwQYCgdrjri52sjo7O6mtreWiiy7CNMyprY1AlEiLn2irD90XBV0idYNYZ5BwnQdiBlqKmexPz8Yxb+xnMVVGR1ICgRDicuBXxFco+6OU8r4jfv8acCfxFco6gc9JKesTv+nAzkTSBinltckok6KcrkK6QXUgxKU5h4d0drnfAkhK/8DmzZsxmUwsWbLkpPeJ9YTofqKaSL3n8EbT4QXZzS4bqWcVYJuWgW2aC82mriHPJCP+0xRCmIDfAJcCTcBmIcRqKeWeAck+BJZJKQNCiH8ivnj9oaWUglLKRSMth6JMFHv9IXQJ81IPd+K63W/icEzF6SwfUd7hcJht27YxZ84cUlNPbsWz0IFeuh+vQsYk6R+dirU4DUthimr3n0SSEdZXADVSyloAIcQTwHVAfyCQUq4bkH4j8OkkHFdRJqSdvsFPFOt6iJ6e9ygsvGXEeW/fvp1IJMKKFStOKr1vYwu9qw9gznaQ/Zk5WHJH3j+hTDzJGD5aBDQO+N6U2HYsnwdeGvDdLoTYIoTYKIS4/lg7CSHuSqTb0tnZOaICK8p42ukNkm7W+p8o7undiGGEyck+f0T5SinZtGkTU6ZMobi4+ITpI41eep8/gH1GFnlfWqSCwCQ2ps8RCCE+DSwDfjpg81Qp5TLgU8AvhRDThtpXSvmAlHKZlHJZbm7uGJRWUUbHTm+QeamHnyh2u99C0+xkZJw1onz37NlDV1cXK1asOOHyjtKQ9DxXg5ZqJeuWmWrkzySXjEDQDJQM+F6c2DaIEOIS4F7gWill+NB2KWVz4r0WeBMYm0nTFWUcxAxJlT/I/EEPkm0mw7V0RE8Te71e/vGPfzBlypSTenbA/34r0WYfGVeXqyCgJCUQbAYqhRDlQggrcAuwemACIcRi4H7iQaBjwPZMIYQt8TkHWMWAvgVFOdPsD4QIGZL5qYf6BwL4fNWkuxadcp5SSp5//nmi0Sgf+9jHTjhkVPdF6HulHts0F44F6u5aSUJnsZQyJoS4G3iF+PDRB6WUu4UQ3we2SClXE28KSgWeTtyyHhomOhu4XwhhEA9K9x0x2khRzig7ffEniucnnij2eHYBBq70Raec5+bNm6mpqeHKK6/kZJpN+9YcREZ1Mq6bfsImJGVySMo9oZRyDbDmiG3fHvD5kmPstwEYmxUzFOU0sMsbxKEJpjvji7h7PNsASE9fOOy8Ds0n9OqrrzJt2jSWL19+wn2inQECH3SQen4xljzVOazEqcZBRRlDO7wB5qQ6MCWuxPs827HbS7Bas4+7XywWo6Ojg2g0SjQapaOjg40bN+LxeMjPz+e66647qat7/3utYBJq4ZgJSEoJUoIQSb+TU4FAUcaIISW7fUFuLMjq3+bxbCPDteyY+8RiMT788EPeeecd+vr6Bv02depUrr76aiorK0+qYjDCMfxb23EuyMWUph4WG4qUkmg4RDjgJxIIEPR5CXm9hHyJl99HyOcjEgwQCQWJBIPEImH0aAw9FsXQdaQ0kIaBlP25HnWMQ5W6lDKRNvFuGBiGcTgPw0AaEimN/v3v+PnvyC4qIZlUIFCUMVIfjODVjf6O4nC4nXC47ZjNQrW1tTz77LN4vV6Ki4u5+OKLSUlJwWKx4HQ6yckZ3lw/gQ86kGGd1HMKR3wup6ug10NHXS3dLU10NzfhdXcS9vsJ+31Ew+F4JZuoaJESCUjDQI9F45V5NDqo0j2SEBq21FRsDgdWuwOLw4nF7sCRZsFksaBpJoSmxV8DgvNRgTpxVS+ESKTVEFr8s6ZpIOLvg34TAhA40tKT/t9NBQJFGSM7Ek8UHxo66vFsByDddXQgiEQiPPfcc1gsFj7zmc9QXl4+ouYAKSW+DS1YilOxlqSdcj6nGz0Wo3HPTuq2f0Djrh101Ndy6FLc6nDgys3HlppKel4BFpstUbmaEquoCYSIV+4mS7wiN1ssWB1ObM4UrA4H9rR0HKlp2FNTsaemYbU7ENqZt4yLCgSKMkZ2eYNYhGBmSvx5gT7PdoQwk5Y696i07777Lh6Ph89+9rNMnTp1xMcO1/QS6wySeVPypqUeL7FolIZd29j//gZqNm8k5PNiMpspnDGbVZ+4lSkzZpFdXEpKRqYaFXWSVCBQlDGy0xtkZoodW+KK0tO3jdTUWUc9SNbb28u7777L3LlzkxIEAHwbWtBSLTgn4HMDUko8ne00V1dRu3UTB7dtIRIMYnU4mbbsLCrPOoeyBYux2Ea+vOdkpQKBoowBXUo+9Aa4Ojc+9bSUOh7vTgoKbjgq7auvvgrApZdempRjx3pChPZ2k3ZhCcJ8ejRrxKJROutrCXm9hIMBIsEg0tDjbfi6TtDnxd/Tja+nm/baGgJ9vQA4XRnMPOc8KpefTcm8hZgtannMZFCBQFHGwB5fkL6YzjkZ8amh/f4adN2P64iO4rq6Ovbs2cMFF1xARkZGUo7t39IOQMqKgqTkd6qCPi87X3+Fhl3bad67h1gkfMy0Qmg4XS6cGZmULVjMlBmzKZwxi5zSqWja8BbbUU5MBQJFGQMben0AnJ0IBP0dxUc8Ufzuu++SlpbGOeeck5TjSkMS2NKGrTITc8b4NJ0Yus6O117m3aceJeTzklMylQUXX0bxnHmkZGRhczqx2O1oJnP/SBmbMwVtmKurKadOBQJFGQMben2UO6wUJqae7vNsw2xOx+ks608TDoepra1l+fLlWK3JGecf2teD3hch45ohJ/UddZ0Ndaz5v5/R1VBHydwFXHj7/0fu1JEtvqMknwoEijLKdCnZ2Ovv7x8A8Hh2kJ62ACEOt9nX1NSg6zqzZs1K2rH9m9rQUi3YZ2WdOHGSNezazvM/+yEWu51rv/YfTF9xthrFc5pSgUBRRtmh/oFVmfHx+4dmHC0r+6dB6aqqqnA6nZSWlibluLo3Qmivm9Rzi8e8k7jqnTd5+be/JHNKIR/71vdIz5l4o5UmExUIFGWUHe4fSAHA493NkTOOxmIx9u/fz5w5c+JPliaBf2s7GJCyPD8p+Z2sD19+gTceup+SOfO59uv3Yk85ubWTlfGjAoGijLINvT4qHDam2OLt/odnHD28gExdXR3hcDhpzUJSSvyb27CWp4/pEpQ7XnuZNx66n2nLVnL1v3xTDe+cIE6PQcWKcoY61D9waNgoxPsH7PZirNbDcwVVVVVhsVioqKhIynFD+3rQ3SFSlo/dkNFd69ay9g+/pnzxMhUEJhgVCBRlFPU/P5A5IBD0bRt0N2AYBtXV1VRWVmJJUuXpXdeIyWUdsyeJd7/1Oq/c/79MXbCYa7/2HyoITDBJCQRCiMuFENVCiBohxD1D/G4TQjyZ+P19IUTZgN++ldheLYS4LBnlUZTTxZH9A+FwJ6Fwy6D+gebmZnw+X9KahcJ1fUTqPKSeNzadxFv+8Swv//YXlM5dwHVfvxdzkoa+KmNnxH0EQggT8BvgUqAJ2CyEWH3EkpOfB3qklNOFELcAPwFuFkLMIb7G8VygEHhNCDFDSqmPtFyKcjo4un/g0INkh58o3rt3L5qmUVlZmZRjetc1oqWYR71ZSErJO399mE3PP8OMs1ZxxZe/ru4EJqhkXC6sAGqklLVSygjwBHDdEWmuAx5OfH4GuFjEBxRfBzwhpQxLKQ8CNYn8FGXC64vGeKfHx6qBzUKe7QhhIi3t8IyjBw4coLS0FIfDMeJjRlp8hKp7SF1VhGYdvSdz+zraeP5n/82m559hwSWXc9W//LsKAhNYMkYNFQGNA743AWcdK01isfs+IDuxfeMR+w65hp4Q4i7gLiBp46wVZTT9udmNXze4vfDwMpQez3ZSUmZiMsUr/WAwSFtbGxdccEFSjul9sxFhM5F69ugsPhMOBNjyj7+zefXf0DQT53/6cyy9+gb1oNgEN2GGj0opHwAeAFi2bJk8QXJFGVcB3eD+pg4uykpjXlp8+KaUBh7vDvLzru5P19gYv4ZKxnTTkRYfwZ1dpJ1XjOY4tX/asUgEd1MDnQ11BL0eDF3H0GN4Ojto3V+Nu7kRpGTWqvM579OfJS1reKukKaenZASCZmDgAprFiW1DpWkSQpgBF+A+yX0VZcJ5vNVNd1Tnq1MPP8wVCBwkFvMO6h+or69H0zSKi4tHdDzdH8X9yB60NCupHxn+wvS97W2sfeB/adyzC2kcvVSjPS2dKdNnMGPluZQvWsqUypkjKq9yeklGINgMVAohyolX4rcAnzoizWrgduA94OPAG1JKKYRYDTwuhPg58c7iSmBTEsqkKOMmYhj8rqGDs1wpnJUxuH8AOCoQFBUVjWjYqNQNuh+rQvdGyPvCQkypJz9qR0rJnvVv8PqDv0fTNJZfeyN5ZdPInVpGamZWfEZQsym+bq5q/jljjTgQJNr87wZeAUzAg1LK3UKI7wNbpJSrgT8BjwghaoBu4sGCRLqngD1ADPiSGjGkTHR/b++hORzlJzNLBm3v82zHZEohJSU+E2gkEqGlpWXEU073vlBLuLaPzJtnDms9YmkYvPzbX7Dn7XUUz57HFXd/jfScvBGVRZmYktJHIKVcA6w5Ytu3B3wOAZ84xr4/BH6YjHIoynj7oM/Pz+vamZtq5+KswZWyx/MhaWnziI+4hqamJgzDOKX+Ad0fJbijE/8HHUQbvaSeV0TK4uFV4h+89AJ73l7HWTfczDk3fUot+DKJTZjOYkU5HUkp8cR06kIRflXXzpquPrItZn45q3RQU0ok4sbr3UN5+Vf7t9XX1yOEoKSkZKis+8V6Q/jeaSFU3Y2MGsiogRGMgSGxFKTguqZi2KOEOhvqePuvf6Zi6QpW3fxp1ewzyalAoCinYJsnwJf21FMfChNLjGFLNWn8e3kBdxXnkmoefHXd3f0uIMnOPq9/W319PQUFBdjtQ68cFusN43mljsD2TkBir8xES7EgLBqa04Jjfg7WwuHP7BmLRFjzvz/F5kzhsi98RQUBRQUCRRmuDT0+PrOzlkyLmX8uySPLYibbauairHSyrUP/k3K738JiySI9bT4Qn3a6qamJZcuWDZle6hL3I3uIdQRIPXsKqecWYc5MzlKTb//1Yboa67nhnu/gdGUkJU9lYlOBQFGG4TW3hzt3HaTEbuWpRdP6p444HikN3N3ryco6t39FspaWFmKx2DH7B7zrm4g2+8j61KykThzX2VDHB2ueZ+GlV1KxeHnS8lUmNjX7qKKcpGp/iDt21jIjxc5ziytPKggAeL27iEa7yc4+v39bfX09MPRT8tF2P57X6nHMy0767KHvPf04VoeDVbfcltR8lYlNBQJFOUmPtbjREDy2oOKYTUBDcbvfAiA769z+bXV1deTm5pKSkjIordQl3c/sR7OZyLhuenIKntBRV8v+TRtYcuX1OFJPfpipcuZTgUBRTkLEMHimvZuP5qSTax3ew1/u7vWkpc3vX4hG13UaGxuHbBbyvddCtNFLxrXTMKUldzrnDU8/js2ZwtKrjpwTUpnsVCBQlJOw1u2hO6pzy5TsEyceIBrtpa9v26DRQq2trUQiEcrKygallVLi29CCtSwdx8LkNgm119ZwYMtGll59vVpDWDmKCgSKchKeaO2mwGrhgszhNal0d78DGEP2Dxx5RxCp86B3x5eXTPaQzg1PP4Y9JZUlV6i7AeVoKhAoygm0h6O87vbwiYJMzNrwKmi3ez1ms4v0tMPzC9XV1ZGdnU1a2uCg4t/ajrBqOOYld0bPtgP7qf1gM0uvvgGbc+wWslcmDjV8VFFO4Om2bgzglilZw9ovFvPT5V5HVtYqNC3+T80wDBoaGpg3b96gtEZEJ7izC8e8HDRbcqd62PTc09icKSy+/Jqk5numk1ISDetEgjqRYIxIKPEK6sQi8Vc0YqDHDIyYga5LpCGREqQxYKb8IybNl0gS/x9/l4l95OH9MQZsk0B/GvjITZWkZNiSeq4qECjKcUgpeaKtmxWuFKY5h/dAV0Pjn4hGuykpuaN/W1tbG+Fw+Kj+gdAeNzKs41yaTzK5mxrYv2kDKz928xl/NyClxN8bpqc1gMcdxOsOEfBEiIR0ouEYsYiRqGzjafv3MySGIdFjEiNmEI3oRMM6sbCOHMbKJ5omECaBEMSb9gbcPB51Hyni6QCElvgsBJqIf0fE80MIRCJNYjdi0aOnCR8pFQgU5Tg+9AaoCYT5+czhTegWDndQX/8AeblXkOFa2r+9rq4OOLp/wL+1HVOGDVu5a8RlHmjTc09jttlYfMW1Sc33dGDoBp0NPpqqu2mr9dBR5yHgifT/LjSBM82C1WHGYjNhtprQTAJhPlzxCohXuiYNk0mgmTUsVg2LzYzZpmF1mLE5zFjtZqwOM1a7aVB+ZquGyazF853AU3WoQKAox/FOjw+Ay3KGV0HX1v4CKWNMm/aNQdvr6urIysoiPT29f5veFyZc00vahSX9V37J0NfRRtW7b7Hkimtwpic3wIwHw5B0NXpp3tdLy74eWvb3EgnFZ63PyHdSMjuLvLI0sotSSc9xkOKyoplUN+jJUIFAUY5jY6+PSqdtWA+Q+XzVtLQ+Q0nJHTidh6/8D/UPzJkzZ1B6/4cdIMG5JLnNQvF1hTWWXn1DUvNNlqAvQjgQi7e1h41E+3i8nTwS1An5owR9EXo7gnQ3++hu9ROLxJtFMvKdTF+eT/HMTIpmZOJMT+4zF5PNiAKBECILeBIoA+qAm6SUPUekWQT8DkgHdOCHUsonE7/9GTgf6Eskv0NKuW0kZVKUZNGlZHOfn+vzM096n1C4jep938VsTqW87EuDfmtvbycUCh3VLBTc2YW1JA1LjiMp5QbwurvYtW4tc8+/5LRZV9jbHWLfprZ4M069h0Bf5MQ7AY50K9mFKcw9t4i88jSKKjOT3lk62Y30juAe4HUp5X1CiHsS3795RJoA8Bkp5X4hRCGwVQjxipSyN/H7N6SUz4ywHIqSdFW+IF7d4CxXypC/S6kTjfYRjfYQCjXT0vo0nZ2vIKXBrJn/jcWSMSj9of6BgR3FuidCtNlH+mUjX7x+oLcefRAhNFZcP+R6UGOqs9HLttcaqNncgWFIMvKdFM/KJLckDUeqBfPA9vtEJ6rVYcaeYsHmjLfPK6NrpP+FrwMuSHx+GHiTIwKBlHLfgM8tQogOIBfoHeGxFWVUvd/nBxi07vAhnZ1r2VP1DWIxb/82szmdkpLPUlz0aRyOoxebqa+vJzMzE5frcHt9qLobAPvM4Q1NPZ7GPTup3rCesz/+SVx5yW1uGo5IKMa7z9Sw550WzDYT8y8oZsHFxaRnJ+/OR0mOkQaCfClla+JzG3Dcv3VCiBWAFTgwYPMPhRDfBl4H7pFShkdYJkVJivf7/BTZLJTYD7c/SylpbHyQ/TU/Ji1tHlMKbsBiycRizSLDtQSTaeghmtFolNra2qOeHwjt7cbksmKZMvRdx3AZus4bD91Pem4ey6/7eFLyPBUt+3t5/eE9eNwhFl9aypLLp2JPGd4cTcrYOWEgEEK8BhQM8dO9A79IKaUQ4pijboUQU4BHgNullIcGwn6LeACxAg8Qv5v4/jH2vwu4C4aeuldRkklKyfu9PlYNmFJCSoPqfd+huflxcnMvZ+6cn2EyndzVbU1NDZFIZFBHsYwZhPb34lyUm7Shh9teXUNXQx3Xfu0/sFjHvh1dGpLNLx5k85o60rPt3PBvSyicnjHm5VCG54SBQEp5ybF+E0K0CyGmSClbExV9xzHSpQMvAvdKKTcOyPvQ3URYCPEQ8PXjlOMB4sGCZcuWDeMxD0UZvvpQhPZIbFD/QEfHGpqbH6e05PNMn35P/yIzJ2P37t04HA7Ky8v7t4UP9iEjOvZZyWkW8nR1suHpRymdv4jpK85OSp7DEQ5EWfvgHup3uZm5soDzbpmh2vcniJH+Ka0GbgfuS7w/f2QCIYQVeBb4y5GdwgOCiACuB3aNsDyKkhTv9x7qHzgcCBoa/4zDMXXYQSAajVJdXc2CBQswmQ5PHxHa2w1mgS0JV8y97W08/YP/QBqSiz77hTF/uKmryctL9+/C5w5x3i0zmHd+0YR+wGqyGWkguA94SgjxeaAeuAlACLEM+KKU8s7EtvOAbCHEHYn9Dg0TfUwIkUv8CextwBdHWB5FSYr3+3xkmE3MSEwr0df3IR7Ph8yY8Z1hBQGA/fv3E41GmTt37qDtoeoebBUZaNaRzS3kbm7kmR/cSywa5aZv/4jsoqM7qkeLYUi2rW3g/dW12FMtXP9vS5gybeI/vDbZjCgQSCndwMVDbN8C3Jn4/Cjw6DH2v2gkx1eU0fJ+r58VrhS0xFVtY+OfMZvTmFJw47Dz2r17N06nc9DzA9GuILGuIKnnFJ5S+aRh0H7wAHXbP+DDl18A4Obv/Jic0rJTyu9U9LT5efOxalr291KxOJcLbp2JI1U92DURqQY8RTlCZyTKgWCYTxXGF6EJhVrp6HyJkuI7MJuHN7onEomwb98+Fi5ceHSzEJxU/0BPazO73nyNpj27iEUi6LEo/t4eQr740NUp02dy+Ze+RlZh0bDKdiqklDRV97D99Ubqd7qx2E1cfPtsZq5M/hoKythRgUBRjrAp8fzAykRHcVPzo0gpKS7+zLDz2rdv39DNQnu7Mec5MGcde0bTtpp9vPXogzRV7UIIjcKZs0nNzsZstlA4YxYlc+YzdcFinK6MYZdrKHrMoK8zGH91BAgHYhhGfMqHoCdCT3uA3vb4dkeaheVXlzPvvCI1vcMZQAUCRTnCB54AViGYl+ZA14M0N/+V3NyP4nAUDzuv3bt3k5qaOqhZyAjFCNf2kfqRY1/B93W08ff7vovJbObcWz7D3PMvJjVreMtknixdN9jzdgubXzxI0Bsd9JumCYQmsKWYySxwMn1ZPgUV6UxfmofZktx1E5TxowKBohxhmyfAnFQHNk2jrW0tsVgfJadwN9DS0kJ1dTUrVqxA0w53MIeqe8CQOGYP3SwUCQZ47n9+gDQMbvrOj8mcMnpNPge3d/LuMzX0dQYprMxg1Y1TcOU7ych1Yk9VD4BNFioQKMoAhpRs9wb4eEG8knZ3r8diySQjY9mw8onFYjz77LOkpKRw/vnnD/otWOVGS7FgLU0/aj/D0Hnxf3+Ku7mRG7/1/VENAnvfa+X1h6vIKkzhqi8tYOq8bNXOP0mpQKAoA9QEwvh0g8VpTqQ06O5+m6yscxFieM0g69ato7Ozk1tvvRWH4/DTx1I3CO3twTE3e8i1BzY99wy1H2zmos99kakLFo30dI7pwIcdvPGXKopnZXLVlxaoZp5JTq3aoCgDbPMGAFiU7sTnqyIS6SI767xh5dHQ0MCGDRtYsmQJlZWVg34LH/QgQzEcc45uFgoH/Gxe/TemLz+bxZddfeoncaLy7XHz6h93k1+ezhVfnK+CgKLuCBRloA89AVJMGtOdNhrr1wOQlfWRk9q3o6ODPXv2sGXLFlwuF5dddtlRaUJV7vjTxJVHr3Gw7ZUXiQQDrLzxlpGdxHH0tgd46f5dZE5J4aovLVRTQCiACgSKMsg2T4CFaU5MQuDufpu01LnYbLlHpfN6vaxfv57e3l6CwSA+n4/e3l4gvh7xRz/6UWy2wZO+SSkJVnVjn5551NPE0XCIrWuep3zRUvLLp43KuRm6wesP78FkElz9pQVqNlClnwoEipIQMQx2+4LcWZxLLOalr28rpaX/31HpampqePbZZwmFQuTl5eFwOCgqKuKcc85h9uzZpKWlDZE7xNoD6N0h0i44ehjqzjfWEvT0seKGm5J+Xod8uLaBtloPl35uDqmZx35+QZl8VCBQlIQ9vhARKVmU7qSn5z2kjA3qHzAMg9dff513332X3Nxcbr/9dvLy8k46/2CVGwDHrMHPA+ixKFte+DtFs+ZSPGvuULuOWGejl00vHGT60jwql4/fYjXK6UkFAkVJONRRvDjdibtuPSZTKi7X4v7ft2/fzrvvvsuSJUu4/PLLsVqH90RtcJcbS0kapiOexK16+0287k4uvevuEZ/DUPSowet/3oM9xcL5n5yphogqR1GjhhQlYZsnQLbFTJHVjLt7PVmZZ6Np8Xb0aDTKm2++SWFhIddcc82wg0CkyUu02Ydz0eD+BiklH7y0mtyp5ZQtXJK0cxloy0t1uJv9XHjbLPWQmDIkFQgUJeFDb4DF6U6CwYOEQs1kZR9uFtqyZQt9fX1cfPHFp3RF7dvQgrCaSFk6uFmm4+ABOusPsuCSK0blSr2z0csHL9czc2UBZfNzkp6/cmZQgUBRAF9MZ58/xKI0J93d7wD09w+Ew2HefvttysvLmTZt+CN6dF+EwPZOnEvz0I4Yrrlz3VrMFiuzVg3vWYWTOq5u8MZfqrClWjj3E5Un3kGZtFQgUBRghzeIJP4gWU/v+9jtJf2TzL333nsEAgEuvviopTdOin9zG+iS1LMHrz0QjYTZ++6bTF9xNvaU1JGewlE+fKWBrkYfF3xyphoqqhzXiAKBECJLCLFWCLE/8X70UzLxdLoQYlvitXrA9nIhxPtCiBohxJOJZS0VZcx94IlPPb0w1U5v7yYyM88CIBAIsGHDBmbNmkVx8fBnH5W6xL+xFdv0DCx5zkG/1WzeSNjvZ/5FHx35CRyho97D5jUHmb4sj4rFRz8HoSgDjfSO4B7gdSllJfB64vtQglLKRYnXtQO2/wT4hZRyOtADfH6E5VGUU7Kxz0+l04YjepBotIfMjHgg2L59O5FIhAsuuOCU8g3u6ULviwy5EtmuN14lPTefkjnzR1L0o/h7w6z57Q5S0m2cd8uMpOatnJlGOnz0OuCCxOeHgTeBb57MjokF6y8CPjVg/+8CvxthmRRlWHQp2dTn47q8THp6XgcgIxEIdu3aRUFBAQUFBcPOVxoS39vNmDJtR61E1tfRTsOu7ZzziVsRWvJaaGMRnTW/30k4pHPjNxappSOTQEqJDIeRoRBGKIQMhzHCYWQkioxEQI8hdR0Z00EaICXSMAZmcESG/f9zOK2U8U3y0GeJlBIMGU87YFvaxRdjOsZDi6dqpIEgX0rZmvjcBhzrSRW7EGILEAPuk1I+B2QDvVLKWCJNE3DMOXeFEHcBdwGUlpaOsNiKctgeXxBPzGClK4WezkP9A0V0d3fT3NzMJZdcckr59r1YS6TBS+aNlUfNNLr7rddACOZecGr9DkORUrLu0b101Hm44gvzySlOfr/D6Ur3eIg0NBJtbCDa1o7e3U2spxvD48UIh5ChMDIahUSlKwdWzlIi9RjoBjIWQ0Yi8Vc4HK/4Q6HxO7EhONa8OPaBQAjxGjDU5dC9A79IKaUQQg6RDmCqlLJZCFEBvCGE2An0DaegUsoHgAcAli1bdqzjKMqwbeyN9w+c5XJyYN8mcnPjFf/u3bsBmDdv3rDz9L7TjO/dFlJXFZKyfPA/H0PX2bXuNabOX0R6zsk/mXzc43WHWPfoXhr3dHPWteVnZL+AlBK9u5twzQEitQcI768hXFNDeP9+9J6ewYnNZsyZmWiudDSbHWG3I6zWeEAWGggRfyUIkwnMJoTJHE9ntaDZbAi7A81uQ9jsaA57/N1uQ9hs8XQWK8Jiju9vMoEQ8Tu8I/KHI4YGC9G/aVB6IeLDiIUATYvvJzi8TQgsp3B3eiInDARSymNeDgkh2oUQU6SUrUKIKUDHMfJoTrzXCiHeBBYDfwMyhBDmxF1BMdB8CuegKCOysc9Hqd2KS68jFuvt7x/YtWsXJSUlZGRknHReUkqCO7roe7EW+9xsXFdVHJXm4LYteN2dXHjH0fMYDVcsqrN/czvvPLUfw5Ccd8sM5p0/+ovYnyppGMQ6u+JX7i0tGIEgMhKOX4HriWYRJEYohBEIYPj9xDo7ibW2EW1rw/B6+/PSUlKwVVaSdsnFWMvKsZSWYC0txVJQgJaerp6gHoaRNg2tBm4H7ku8P39kgsRIooCUMiyEyAFWAf+TuINYB3wceOJY+yvKaJJS8l6vj0uzXfT2vAFAZuZKOjo6aG9v54orrjjmftEWP3pfGCOsY/ijRBo8hA/2YXijWEvSyLp55pCLz2xf+xKpmVlULFlxUmUM+aM0VnXT1ehFj0oM3SAUiOFu9tHTFkAaksLKDC76zGxcuY4TZzjGom1t+N58C9+bb+LftAkZCJx4J01DS0lBczgw5WRjKSnBuXw51qmlWKdNxzZ9Gub8fFXZJ8lIA8F9wFNCiM8D9cBNAEKIZcAXpZR3ArOB+4UQBvFRSvdJKfck9v8m8IQQ4r+BD4E/jbA8ijIs+wJhuqM6KzNS6Ol6H4e9FLu9kA0b3kAIwZw5c47aJ9oVpO+FA/G1hwfQ0q3YKjKwVbhwLsw9aqppiHcSH9y2lZUfuwWT+fj//Op2drH1pTraD3qQEjSTwGTR0EwCi81EdlEq5QtzyJuaTvmCnCGDzniRUuLfsIHuhx/Gv/5tACzFxWRcfx3W6dOxlpRiKS6KV/Y2G8JiOdy0AmCxqEp+DI0oEEgp3cBRvV1Syi3AnYnPG4Ahx8dJKWuBk7ssUpRR8F6vD4CVLicN+zeRm3spUkp27dpFWVnZoCmlpS7xvFaPd30TwqzhurIcW4ULYTej2U1oKSeuvHa8/jICccJnB7a/0cg7T+8nI8/J0ivLmDo3m7yydLTTqLIfitR1PC+9jPuBBwjv24cpJ4ecu+8m/fLLsE6bpir305SafVSZ1Db2+phis5Ct11Gb6B9obW2lu7ubc889d1Ba71uNeNc14lych+vKckxpwxuaqcei7Fq3loqly0nPGboz1zAk7zy9n53rmihfmMOln5+LZYg7i9ONNAy8r75K569/TaTmANbp05jyox+RfvVVaMOcoE8ZeyoQKJPWof6BczJSB/QPnMU77+xBCMGsWbP600Za/Xheb8CxMJesm2ee0vFqNm8k0NfLwkuG7ncAeOuv1ex5u4VFl5Rw9semn/Z3AEYwSN/zq+l++GEiBw9iraig6Of/j7TLL0/q8xHK6FKBQJm06oIR2iMxVmak0tWxjpSUSuz2Qvbu/TtlZWU4nfEpIaRu0PNUNZrDTMa1p7aMpJSSD1/+B+m5+UxduHjINHU7utjzdguLLy3lnBunn/J5jTbd5yew6X3877yDZ81L6L292OfOpfBnPyP9isvjQymVCUUFAmXSOtQ/sCJN0LpvE6Uln6Orq4uuri6WL1/en867rpFoq5/sT8/GdIqTtx3Yuonmvbu58I4voGlHV5QhX5R1j+4luyiVs649esjpaJNSEt63j8iBA8S6uoh1dmEEAiANpGFg+APxYZxdnUTqGyAaRTidpJ57LlmfuQ3H0qWq/X8CU4FAmbRe6Oyl0GYhK7iZFhkjO+cidu/aC9DfLBRt9+N5oxHnolwc805tPv9YNMpbj/yRrKISFl46dLPQ+ieqCfmjXPOVhZgsY9ekEmlspO/51XhefJHIwYOHf7BY0JzOeOWuaWgOB+bcXGzlFaRdeCEpq87FsWSxav8/Q6hAoExKTaEIb3Z7+Zep+bjdD2M2u3ClL2bv3j9TWFiIy+UCwPtWE8IkcF1zak1CANtefoHetlY+9q3vDTlkdP+WdvZv6eCsayvIKU7u1AHHIqNRuv7wB7p+93uIxXAuX07WHXfgXLIYc24umsulrvAnERUIlEnpydZuJHBLQSb1W9eRnX0+fn+QpqYmLrroIgB0T3xBmZQVBafcJBTo6+W9vz1B+eJllC9aetTv0bDOO0/vJ29qGksuG5s5tELV+2j91rcI7dlD+lVXkfeNr4/KtAXKxKECgTLpGFLyRFs3H8lMJSO6l5poNznZF1JdXQ0cbhbyvdcChiTt3FObskFKydt/fZhYJMz5tw09w/q21xoI9EW4/K75aKbRbxLyvvYazV/7N7S0NIr+739Jv/TSUT+mcvpT47uUSeedHh+NoQi3Tsmmy/0GQpjIzj6PqqoqsrKyyM3NxYjo+Da2Yp+TjTl7+NM26LEoax/4P3atW8uSK68ju6jkqDT+vjAfvNrAtCW5TJnmSsapHVfP00/T9JWvYps9i4rVz6sgoPRTdwTKpPNYq5sMs4nLc1xsr1+HK30Jum7n4MGDrFy5EiEE/q3tyGCMtI8M/24g4OnjhZ//mKaqXaz82M2c84lbh0z3/upajJjB2Tecev/DyZBS4r7/fjp/+StSPvIRin/1SzSn88Q7KpOGCgTKpNIdjfFSZx+3FWZDtB2fbw/Tp/07+/fvxzAMZs2aFV9Q5p1mrCVpWKemD5mPlJK2A/sI9PUSCYWIBPz0tDbT1dhA+4H9RCNhrvzy15l97gVD7t/V5KNqQysLLyrBlTt6lbKUko6f/A/df/4z6ddcQ+GPfhif10dRBlCBQJlUHmtxE5GSTxVm09X1dwCycy7inXc2kZaWRnFxMaG93cTcIbIuKztq5EwsEmHP2+v4YM3zuJsaBv1mtljJLill2rKzWHTZ1RRMqxyyDFJKNvxtPzaHmWVXlo3KeUJ83p+2736X3qefIfPWW8m/9z/U077KkFQgUCaN5zt6+HFtK5dkpzMnxcbGXQ+TmjoLQ8+npqaGVatWoWkavvdaMKVbccwd/NxA24H9PPuT7xHo6yW3rILL/ulfyCmZisVux+pwkJKROeTDYkeq3dZJY1UP595Uif0URyOdiBEO0/qtb+FZ8xLZX/wCuV/9qhoOqhyTCgTKpPByZx//vKeeFa4U7p87lc7OtQQCB5g795fs3LkTKSWLFi0i5g4S3t9L+iWlCNPhirO7pYm///g7WOwObvr2jyieM/+UKtZoJD5cNLsolfmjtIBMuPYgzf/6r4Srq8n7xtfJ/vzQI5YU5RAVCJQzUkg3aAhFOBgMU+UL8vO6dhamOXlkQQVOTWN3/W9xOKaSl3sFf3vmfoqLi8nJyaF3zUHQIGXF4XH13u4unvnhf4EQfPze75M55dQr8K0v1eHrDnPpv81N+nBRKSWe1atp/d730axWSu7/Pannn5/UYyhnJhUIlDOCP6bzPwfb2NDrozkcoTuqD/p9WbqTRxdUkGY24Xa/jde7i9mzfkxrazudnZ1cffXVyKhBYEsbjjnZmNJtAIQDfv72w28T9vu46ds/HlEQ6O0I8OHaBmaclU9hZcZITncQ3eul7/nV9D75BOH9NTiWLaXoZz9TD4kpJ21EgUAIkQU8CZQBdcBNUsqeI9JcCPxiwKZZwC1SyueEEH8GzufwQvZ3SCm3jaRMyuSzuc/Pl6vqqQ9GuCArjcXpTgptFortViqcNiocNjIsh/+q19X/DputgIKC63nppbWYzWbmzp1LYFcXRiBGysop/WnffvzPdDc38fH//AH5Fac+I6hhSN56vBqTWeOcj518PnpfH+F9+wjt20e0uQUZi4JuYIRDxNo7iLW1EmloRIbD2OfNY8p//wDX9dcjTrD6maIMNNK/LfcAr0sp7xNC3JP4/s2BCaSU64BF0B84aoBXByT5hpTymRGWQ5mkflHXxk8PtlFkt/Ls4umszEg9bvre3i309r5PZeV/ouuCnTt3MmvWLBwOBx0b92HOcWCryACgZd9etr/2MkuvvJbSeQtHVM4Nz9TQtLeHC26dSYrLdsL0wZ076fzFL/Fv2NC/TQxY0lGzWjHn52MtKyNl1bmkX3UVjvnzRlRGZfIaaSC4Drgg8flh4E2OCARH+DjwkpTyJFavVpTj+0dHLz852MbH8jP5nxnFpJqPP2Knz7Odnbu+jMWSTVHhzVRVVRMKhVi0aBGRVj+Reg+uq8oRmsDQdV77429Izcw65gNhJ2vXW01sf6ORhReVMPcED6hFGhro+OlP8a59DVNmJjl3341jwXxsM2dizstTI3+UUTHSQJAvpWxNfG4D8k+Q/hbg50ds+6EQ4tvA68A9UsrwUDsKIe4C7gIoLR2bybmU01dLKMLXqxtZmObgl7NKsJ5gfHxb22qq9t6D1ZrHwgUPIKWVdevWkZWVRUVFBb1P70dYNFKWxv8Kf/DSajrrD3Lt1/4Dq+PUH/hq2O1m/ZP7KZufzTkfP36TUOCDD2j6p39GxmLk3H03WXfcjin1+Hc4yplHSolEIqWMf0cO+t0kTEm/IDhhIBBCvAYM1et078AvUkophJBDpDuUzxTii9i/MmDzt4gHECvwAPG7ie8Ptb+U8oFEGpYtW3bM4yhnPl1KvlzVQERKfjenrD8IxGI+AoGDRCJdRCKdhMLthEMtBENN9PRsIMO1nPnzf4PVms369etxu93ceuut6O4QgW0dpJ5bhOa04OnqZMNTj1GxZDnTV5x9SmUMeiNsfrGO3eubyS5K4dLPzz3uspOeV16l5RvfwDJlCiV//APWkqPnJlLipJQEY0HcITc9oZ74K9yDJ+zBE/Hgj/oJxoIEY0EieoSYjBEzYhjSGLJyPVTpSiSGNNANHUMa/fvFjBi61IkZMaJGFN3Q0WXiZej9+xnSiOd7gtppqGMfuf14nr/+eSpcyV286ISBQEp5ybF+E0K0CyGmSClbExV9x3Gyugl4VkoZHZD3obuJsBDiIeDrJ1luZRL7bUMH7/b6+PmsEiqcNgwjTGPTI9TV/ZpYzDsordWag802hdLSO5lW8W9ompWenh7Wr1/P7NmzqayspPupaoRZI+28YgDWP/YQ0jC46LNfOO6VVzSiEwnG0KMGsYhBwBPG1xumpzXArreaiEYM5pxbyFnXlmO1H/ufWs8TT9D2ve/jWLiQ4t/9FnNmZnL+Q51GvBEvDZ4GGn2N9IX68EQ8eCPeeMUq9f5K+tD/6YZO1IgS0SMEY0H8UT/eqJe+cB+9oV4iRmTI4wgEKZYUHGYHdrMdm8mGWTNjEiZMwgQinuZQ2kM0oSGEQCCwm+3x9JoJszD3v5u1+MukxfMya2Y0ofVfoQsEmtCOyvtEDu078LOIF3TIsmbakv/3Y6RNQ6uB24H7Eu/PHyftJ4nfAfQbEEQEcD2wa4TlUc5w9cEwPz3YxlW5Lj5ZkEVX1zr27fs+wVAD2dnnU1R4C1ZbPlZLDjZbDpp2dMfsSy+9hBCCyy+/nFhXMH43cE4RpjQrzdVVVG9Yz8obb8GVd/SNcG97gNrtndTt6KLtQB/yGBdxZQtyOPuGaWRNSTnu+fQ+9xxt3/0eqRdcQNEvf4Fmt5/Sf5fTiS/iY0fnDrZ3bWdH5w72uPfQHeo+Kp1Vs2I1WQdVphCv9MyaGYtmwayZcVqcpFnSKE4tZl72PDLsGWTaMsm0Z5JlzyLTlkmGPYN0azpp1rT+ylg5eSMNBPcBTwkhPg/UE7/qRwixDPiilPLOxPcyoAR464j9HxNC5AIC2AZ8cYTlUc5wP6xtxSQEP6wspsv9Bjt2fJGUlGksWvgQ2dnnnXD/7du3s2/fPi699FJcLhfdT+8DTSPt/GKkYbDuzw+QmpnF8mtvHLSfHjN477kDbH+tEYCcklSWXDaV1EwbJouGyaLhTLeRmmkjNcOG2XriqSa8r71G673/ifPslRT96pdothOPJjoddQY62dG1g+0d29nctpmq7ip0qSMQTMuYxnnF51HuKmdq2lSK04rJsmeRbkvHZpqY53smGlEgkFK6gYuH2L4FuHPA9zrgqOESUsqLRnJ8ZXLZ0udndUcv/1aWjyO8hw92fYW0tDksWfw4ZvPxr7z9fj8vv/wyO3fupKioiJUrVxJzBwl82E7q2YWY0qzsfut12mv3c8WXvobVfngNgt72AK/+aTedDV7mnV/EksumkpY1sit3/3vv0fyvX8M+by4lv/71aREEAtEAfeE+ArEAgWiAiBHpb7+OGtH+7T2hHhq9jTT5mqjpraHN3waARbMwP2c+n5//eZbmL2VBzgJSraqzeyJQT50oE4KUku/VtJBnNXNHTojt2+7EZs1j4cI/9QeBaDSKx+MhEAgQDAYJBAL4/X58Ph/bt28nFApx/vnn85GPfAQNja5na0ATpJ1fTCQU5O2/PkzB9BmDpo5uqu5hzW93oJkEV3xxPhWLckd8Lv6NG2n8p3/GWlZG6f33o6UcP4iNBikl1T3VvNHwBnvce6jpraHZ13zS+6dZ0ihOK2Zx3mLm58xnfs58ZmfPVlf5E5QKBMqE8I/OPjZ7/Py0Mo/9u24DJIsWPYjNmkNfXx+bNm1i69athEKho/Y1m80UFRVx5ZVXkp8fHx7a+49awjW9ZN5YiSndxtt/+QP+nm6u/dq3+qdqbj/oYc1vd5CaZeeaLy8c8V0AgH/DhngQKC2l9M8PYcrIGHGew9HkbeKpfU/xat2rNPua0YRGhauC+TnzuX769eQ783FYHDjNTiyapb/d3qJZcJqdOC1OXFYXLpta3P5MogKBctoLGwY/rG1hVoqdxZ5f0x6sZ8nix7FYinnhhRf48MMPkVIye/ZsZsyYgdPp7H+lpKRgtVoHVVr+re343mkm9ZxCUpYXUL9zG1tffJ5Fl11F4YzZALhbfLzw62040ixc99VFpGSM/ErX9/bbNN395fidwEMPYs7KGnGeJ0NKyZb2LTy651HebHoTgeDswrO5a8FdXFhyIZn2M2+UkjI8KhAop70HGjupC0a4v8xD+8EnmVr6BWy2eTzyyCM0NDSwYsUKzj77bDJPYthlaF8PPc/ux1bhwnVVOSG/j5d/90syC4s579bPAuDpCvLCr7ZhMmtc+9XFIw4CRiRC1//9H+4//gnbzJnxIDAGQ0SjRpRX6l7hL7v/QlV3FS6bi8/N+xw3z7yZghQ1IZ1ymAoEymmtNRzhF/XtXJZlJ7PpLmyps8nKuoMHH3yQnp4ebrzxRubPn3/cPKSUhPf34nmjgUidB1O2naxbZyNMGm88+HsCvT188gc/w2KzE/JH+cevtxOLGtzwb0tw5Q5/4fqBgrt203rvvYSrq8n4xCfI++Y3MaWOXp/Aobb/NbVrePHgi3QEOih3lfNfK/+La6Zdg8M8svNRzkwqECintf8+0IpuSD5p/JFYzEvl9N/y0EOPEI1Gue222ygrK0NKSbTFT3BXF7GuIEYohgzpGKFY/BXUIWZgcllxXVNByvICNKuJHa+9TNU7b3LOTbdSMK0SPWrw0u930tcV5NqvLCK76MQjXqSUEI0io1F0vx/D60Xv7sb37rt4X3uNSM0BTDk5FP/+d6RdcMEp/3eQUhLWwxjSACAmYwSiAfxRP92hbvb17GNv9162dWyjzlOHWZg5p+gcvnP2dzi36Fw1tl45LhUIlNPWpl4ff2vv4fNZnVjcz1Ja+nWeeeY9otEod9xxB/k5eXheb8C/tR29OwQamHMcaHYzwm7CkmFDcyQ+56fgXJiLMGvxNYOffpz3nnmcsoVLOOv6m5BS8sYjVbTs7+XSz82haMbRTTexri48a9YQ2lNFeN8+wrW1yCE6pwHQNJzLl5N5yydxXX3VSXcKSylp9jWzuW0zW9q3sL9nP92hbrpD3USN6HH3zbJnMTt7NrfNuY2PTv0oGfaTO6aiqECgnJaihuTe/c0UWODc7m+QmXEub75ppre3i9tuu43MiJP2//2AWEcQW2UG6ReWYJ+TjekEawDrsShrH/gNu996jbnnX8yld92NEBpvP7GPfZvaOeu6CmasGNx+Htyxg+5HHsXz8ssQjWLKzcFeOYPMm29CS01DWCwIixktJRVTehpaWjr2eXOH1Q/gj/p5sfZFnqx+kn09+4D4VAJzcuYwI3MGWY4s0q3paEJDQ0MTGimWlP5RPNMzp5PryFUjeZRTogKBclr63oFmdvqCfMP6CKkWO/v2nUtTUzOf+PgnyKiSdK7fjindRs5n52KfefzRN3osStuBGqrfW8/+je/i6+nm7I9/irM//kkMQ/Law3vY9347iy8tZenlU/v3i7a30/6jH+N95RW0lBQyb76ZzE99CltFedLOsyPQwUO7HuLZmmfxR/3MzprNPSvu4ayCs6jIqFBNOsqYUIFAOe083urmj01dfNy5l0X+5+n23snevc1cccll5G008NU0kbKiANeV5RiaQVPVLpr37qG5eg8+dxfRSJhoOEwsHCYaDmHo8WUrTRYL5YuWMv+iy6hYspxYVOfVP+7m4PYuVl5fwZLLpiKEQOo6PY89TuevfhWfEvorXybrM7cntZO3zd/Gg7se5G/7/oYuda4ov4JPzvok83Pmq6t6ZcypQKCcVjb3+flmdRPL7W6u9f8X0cglfPhhiAvO+ghTN1oI9/SReWMlYoad957/K9teeZGQ3wdAVlEJmVMKsdjsWGw2zDZb4rMdV34BFYuXY3M6kVJSu62TDX+roa8zyHm3zGD+BfGZR8M1NbTcey+h7TtIOfdcCr79X1iTuP5FdXc1f9nzF9bUrgHguunX8fn5n6ckTU07rYwfFQiU08bGXh//36468kw+7gx+DaGvZOPGfFbOXkrl+w4MU5S0T1Ww8f3n2PWrV4nFokxftpK5519M4czZONNdx83f3xemeVsnO9Y10lzdS2aBk2u+spDSOdnIaBT3nx6k6ze/QUtJofCnPyX96quScnXe6mvljcY3eK3+Nba0b8FhdnDLrFv49JxPU5R6/BXLFGUsqECgjDtPTOe/D7TwlxY3BSY/X4n9B1pgLu9uqWBRwRzmfujCNMVOW2kL7/y/XxINhZh7/sUsu+ZjOF35dLf4qdvhp6e9k5Avgh6TGDEDvf8l8bpDeLvjI3zsKRbOu2UGcz5SiCbA89JLdP7yV0Tq60m74nIK/vM/MWdnD1nWQDTQvyBKb7iXqBFFSoku4/PnR/UoIT1Eq7+VBk8DB/sOUttXC0CFq4KvLvkqn5jxCVy24wetCU2PQqgv/gp7IOyFaDD+ioVAj4ARA0MHaRCfy3vAfN6HvkuZ+N04nN6IxvfXo4lXIi89Gv+tP50O8oj8jzVn+FHHPqIMyCPyOVaep7Be1snsf+TmWx6FzLLhH+s4VCBQRlVAN/DrOgHdIGgYGDK+wphPN9jtC7LdG+BNtxd3NMo1pje5PvYHvJ2z+LB6Jue65jOzLgej3MSr+x6kc0MdUxcsZtnVt9HdbuPNx9tpO7Cv/9+SyaLhSLVgMsenhdZMIv7ZrJFXls6Ci4rJL3eRW5qKCPrxvfgPuh/+C6Hdu7FVVh411l83dHa7d7OpbRN73HuoclfR5Gs6qfO2aBaK04qZmjaVa6ddy0WlF1HuSl4n8ykzDPB3gr8j8e6OV9YRP0QDiYr1UCU6sII0Dm/XIxALJyr3AIQ88TxCnnjlH/WP4gkIMFnBZEm8rKBZwGROvFtAmEDT4u9CAyHi+x16HzJbMfgYh9JqR+wvtMG/H5nnKd1Bnsz+A7Zrxx8ZdyqEPGaUPH0tW7ZMbtmyZbyLoRzBE9NZ3+1lU5+fKn+QKl+Qrqh+3H0ytSDTOMC1+l8ojQbYt282UW8lF/rnkifS2c92Ptj/Mq78KVQsuR53Wx4ddfFVyHJKUimbn0PBNBcZ+Q5SLDFkKAixGFLXkboOiXe9r49ocwvRlmaC27bj37gRolEsxcXk3P0lXNdcgzCZ6An18Hbz27zd9Dbvtb5HX7gPgJK0EmZnzWZm1kzynHlk2bNw2VxYtcMLq1hMFqyaFYvJQqYtE5N24jUJkkLK+JV22BevkP1d8Yre1wGeZuhrOvzytMSvnI9FmEAzHX4//MPhytVkAYsDzI74uz0dbGlgSwd7Bjgy4u/929PAkpLYx5aovM3xV39FzeBKcGCFq5kPl2es/pueoYQQW6WUy47argKBMhI1gRAvd/bxSmcHH3hj6AisRCmmiRJZSz6tOAhiI4yVMCYMNAysRCihnrRYjIDfRWPTdEK906mMTWF+uIRumtjcsAZpM5FZfCGe7goMXZCZ72BaSZRCowFTw14iNQeItrWhu93I6PEfuDrEMrWUtIsvIf2jl2LMns529w62tm/l/db32dG5A4kkx5HDqsJVrCpaxcopK0dnYrZoEHobobcB+hrB2xqvqP2d8SvrYG/8Sl2PHL5S7ycHNIPE4lfqQ9HMkFYIriJwFUN64j01D1JywZkTr7AtTrCmqIr2DDcqgUAI8Qngu8BsYEViQZqh0l0O/AowAX+UUt6X2F4OPAFkA1uB26SUQy9GOoAKBOOnNxrjvZ4+3ups4o2eIA3R+NTMU2Uti/iQufpOCrxdRIKphIJphMNOdN2MYZgwDBMSAVJgGCZEKBtnNJ006aBczyNfd9LqP0B172ZCVjNocxCmOTisJopEE3kNb2Ov3ohI/J3VMjOgohQ9P5uYK4VoupOY04LUNKQm4i+ThqEJInYTniw7PS4TnXovDd6G+Bq63kZ0qaMJjTlZcziv+DzOKzmP2VmzD4/hN4x4c0fYd7hiNqKgxxjcjjygTVsPQzSUaDrphUB3/Erd23r46tx/5BLfIl5Bp+Ylrqhd8avp/iYQM4ObCA5dJZvjlbg1DWyp8Qo+JTeRV76q3JV+oxUIZgMGcD/w9aECgRDCBOwDLgWagM3AJ6WUe4QQTwF/l1I+IYT4PbBdSvm7Ex1XBYIT06UkrBtEjBgRPUZIjxLRo8QMnZhhxBcLH9ALFV8w3CCaSN8bDOIO+nCHgjQEg9RFoYkUWkUWUmhYZJiZVLEwup2K3gZsPQ60vnJSvSW4ZCo2XcOiS0y6gZAG0jAQxOtKgQQMInqIkO4nqPvoDLfj0TWEKR+TdQapUYPM7n3kdm4ns3cfoXQrrSVODhRqVOVF2JUdojfl1P7uOjQrJfZsplozKLdksNSSyULNSUokAAF3vNIOdkOwJ/4K9SXnD8XmgrSC+BW5qwhcJZAxFTKnxq/U0wrilb6ijJJjBYKRLlVZlcj8eMlWADVSytpE2ieA64QQVcBFwKcS6R4mfndxwkBwqj6x+gEOOJM/XE8Os4NIHqvD6gTpBn430JAIDKGho2FgQsdEDDMxzMgRP5EqgDQgDZOMkS/ayDfqWBx6nwqPm7IuHZs7H0tfBVqkhGgkQsCI0au30h7TEWiYpAlNxjvTRPwEEmcgAYHZEJgMidmwkhPKojDSjTR24jf9g06Xn7opgvqF0Jgn0FLC5MYCZOs6BbrOnIhBRsggw9BJMSQOw8AuJZZEoDnUhacljmlBkmYYpBgSu5QIao46Y79Iwaul49PS4i9Rjk9bgC81laBwEhIOQsJOTFiICTM6JiRa/5+NFKL/zygirESEjQg2fFoqPi0dXST+uQUSr9bDf7Lxa6ST64hWJq85hel855q5Sc93LEYNFQGNA743AWcRbw7qlVLGBmw/Zi0thLgLuAug9BQf8MkIBiiwdJ3Svid0jItTMegHcYztJ0cg+4+jIdGkkajsDEzS6H83GxKT1DEbBiZDYjLi202GRJMSzZD9FfNA8f1BkxJbRMcRMnCEYqT1GuCxQDRGNBYkYvjwmcL4TO0YphCYwhiOMIYpgmHSkWaBYdJAOxwkpeg/icP/uTQNaYo34+hWE5rFgklq2GQxVmllqrQwQ9oxR2wYUTNRLAMqYTO9woTbnKiQhUgEx8EBUPa/CwwRD5a6MBMWNiJYCQs7AS2FoHAghWpCUSanEwYCIcRrwFCrWNwrpXw++UUampTyAeABiDcNnUoef7j5X5JZJEVRlDPCCQOBlPKSER6jGRj4/HxxYpsbyBBCmBN3BYe2K4qiKGNoLKY23AxUCiHKhRBW4BZgtYz3Uq8DPp5IdzswZncYiqIoStyIAoEQ4gYhRBNwNvCiEOKVxPZCIcQagMTV/t3AK0AV8JSUcncii28CXxNC1BDvM/jTSMqjKIqiDJ96oExRFGWSONbwUbXqhaIoyiSnAoGiKMokpwKBoijKJKcCgaIoyiQ3ITuLhRCdQP0p7p4DjNLjxePuTD03dV4Tz5l6bhP9vKZKKXOP3DghA8FICCG2DNVrfiY4U89NndfEc6ae25l6XqppSFEUZZJTgUBRFGWSm4yB4IHxLsAoOlPPTZ3XxHOmntsZeV6Tro9AURRFGWwy3hEoiqIoA6hAoCiKMslNqkAghLhcCFEthKgRQtwz3uVJBiHEg0KIDiHErvEuS7IJIUqEEOuEEHuEELuFEF8d7zIlgxDCLoTYJITYnjiv7413mZJJCGESQnwohPjHeJclmYQQdUKInUKIbUKIM2rWy0nTRyCEMAH7gEuJL4u5GfiklHLPuBZshIQQ5wE+4C9SynnjXZ5kEkJMAaZIKT8QQqQBW4Hrz4A/MwGkSCl9QggL8A7wVSnlxnEuWlIIIb4GLAPSpZRXj3d5kkUIUQcsk1JO5AfKhjSZ7ghWADVSylopZQR4ArhunMs0YlLK9UD3eJdjNEgpW6WUHyQ+e4mvZ3HMda0nChnnS3y1JF5nxBWZEKIYuAr443iXRTl5kykQFAGNA743cQZUKpOFEKIMWAy8P85FSYpE88k2oANYK6U8I84L+CXw74AxzuUYDRJ4VQixVQhx13gXJpkmUyBQJighRCrwN+BfpJSe8S5PMkgpdSnlIuJrda8QQkz4Zj0hxNVAh5Ry63iXZZScK6VcAlwBfCnRLHtGmEyBoBkoGfC9OLFNOY0l2tD/Bjwmpfz7eJcn2aSUvcTX7r58nIuSDKuAaxNt6U8AFwkhHh3fIiWPlLI58d4BPEu8ufmMMJkCwWagUghRLoSwArcAq8e5TMpxJDpV/wRUSSl/Pt7lSRYhRK4QIiPx2UF8AMPecS1UEkgpvyWlLJZSlhH/9/WGlPLT41yspBBCpCQGLCCESAE+CpwxI/UmTSCQUsaAu4FXiHc6PiWl3D2+pRo5IcRfgfeAmUKIJiHE58e7TEm0CriN+JXltsTryvEuVBJMAdYJIXYQv0BZK6U8o4ZanoHygXeEENuBTcCLUsqXx7lMSTNpho8qiqIoQ5s0dwSKoijK0FQgUBRFmeRUIFAURZnkVCBQFEWZ5FQgUBRFmeRUIFAURZnkVCBQFEWZ5P5/UGzlUb1L05EAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "T = 7 * 0.399128 / r\n",
     "\n",
     "for amp in np.linspace(0, 1, 10):\n",
     "    ys = jitted(amp)\n",
     "    plt.plot(np.linspace(0, T, 100), np.real(np.abs(ys[:, 0])**2-np.abs(ys[:, 1])**2))"
-   ],
-   "outputs": [
-    {
-     "output_type": "error",
-     "ename": "AttributeError",
-     "evalue": "'HamiltonianModel' object has no attribute 'drift'",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-14-2d4035736071>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mamp\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlinspace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m10\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m     \u001b[0mys\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mjitted\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mamp\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m     \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlinspace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mT\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m100\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreal\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mabs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mys\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mabs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mys\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/VSCodeWorkspace/QURIP/qiskit_dynamics_work/qiskit-dynamics/qiskit_dynamics/dispatch/wrap.py\u001b[0m in \u001b[0;36mwrapped_decorated\u001b[0;34m(*f_args, **f_kwargs)\u001b[0m\n\u001b[1;32m     87\u001b[0m                 \u001b[0;32mfor\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mval\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mf_kwargs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     88\u001b[0m             )\n\u001b[0;32m---> 89\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_wrap_function\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdecorated\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mf_args\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mf_kwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     90\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     91\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mwrap_return\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/VSCodeWorkspace/QURIP/qiskit_dynamics_work/qiskit-dynamics/qiskit_dynamics/dispatch/wrap.py\u001b[0m in \u001b[0;36mwrapped_function\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    114\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    115\u001b[0m         \u001b[0;31m# Evaluate function with unwrapped inputs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 116\u001b[0;31m         \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    117\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    118\u001b[0m         \u001b[0;31m# Unwrap result\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "    \u001b[0;31m[... skipping hidden 12 frame]\u001b[0m\n",
-      "\u001b[0;32m~/VSCodeWorkspace/QURIP/qiskit_dynamics_work/qiskit-dynamics/qiskit_dynamics/dispatch/wrap.py\u001b[0m in \u001b[0;36mwrapped_function\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    114\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    115\u001b[0m         \u001b[0;31m# Evaluate function with unwrapped inputs\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 116\u001b[0;31m         \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    117\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    118\u001b[0m         \u001b[0;31m# Unwrap result\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m<ipython-input-12-7571f793c76a>\u001b[0m in \u001b[0;36msim_function\u001b[0;34m(amp)\u001b[0m\n\u001b[1;32m     12\u001b[0m     \u001b[0mham_copy\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mhamiltonian\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m     \u001b[0mham_copy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msignals\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msignals\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 14\u001b[0;31m     \u001b[0mham_copy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mframe\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mham_copy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdrift\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     15\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m     \u001b[0;31m# simulate and return results\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'HamiltonianModel' object has no attribute 'drift'"
-     ]
-    }
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "In the above oscillatory behaviour is due to the RWA not being entirely accurate in this system."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [],
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": []
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "5e5310ab1df1c80c820dafd4ba8dc30a2e69417f6a636c7d3a734a0f9d392399"
+  },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.5 64-bit ('base': conda)"
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -458,10 +462,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
-  },
-  "interpreter": {
-   "hash": "5e5310ab1df1c80c820dafd4ba8dc30a2e69417f6a636c7d3a734a0f9d392399"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/qiskit_dynamics/models/rotating_frame.py
+++ b/qiskit_dynamics/models/rotating_frame.py
@@ -227,7 +227,7 @@ class RotatingFrame:
             out = self.state_into_frame_basis(out)
 
         # go into the frame using fast diagonal matrix multiplication
-        out = (np.exp(-t * self.frame_diag) * out.transpose()).transpose()  # = e^{tF}out
+        out = (np.exp(self.frame_diag * (-t)) * out.transpose()).transpose()  # = e^{tF}out
 
         # if output is requested to not be in the frame basis, convert it
         if not return_in_frame_basis:
@@ -318,7 +318,7 @@ class RotatingFrame:
         # get frame transformation matrix in diagonal basis
         # assumption that F is anti-Hermitian implies conjugation of
         # diagonal gives inversion
-        exp_freq = np.exp(t * self.frame_diag)
+        exp_freq = np.exp(self.frame_diag * t)
         frame_mat = exp_freq.conj().reshape(self.dim, 1) * exp_freq
         if issparse(out):
             out = out.multiply(frame_mat)

--- a/qiskit_dynamics/models/rotating_wave_approximation.py
+++ b/qiskit_dynamics/models/rotating_wave_approximation.py
@@ -35,7 +35,8 @@ def rotating_wave_approximation(
     return_signal_map: Optional[bool] = False,
 ) -> BaseGeneratorModel:
     r"""Construct a new model by performing the rotating wave approximation with a
-    given cutoff frequency.
+    given cutoff frequency. The outputs of this function can be used in JAX-transformable
+    functions, however this function itself cannot (see below).
 
     Performs elementwise rotating wave approximation (RWA) with
     cutoff frequency ``cutoff_freq`` on each operator in a model, returning a new model.
@@ -58,6 +59,41 @@ def rotating_wave_approximation(
         rwa_model.signals = f(new_signals)
 
     result in an ``rwa_model`` with the same updated signals.
+
+    .. note::
+        The ``rotating_wave_approximation`` function itself cannot be included in a function
+        to-be JAX-transformed, however the resulting model and ``signal_map`` can. For example,
+        the following function is **not** JAX-transformable:
+
+        .. code-block:: python
+
+            def function_with_rwa(t):
+                operators = ...
+                signals = ...
+                model = GeneratorModel(operators=operators, signals=signals)
+                rwa_model = rotating_wave_approximation(model, cutoff_freq)
+                return rwa_model(t)
+
+        Whereas, defining:
+
+        .. code-block:: python
+
+            rwa_model, signal_map = rotating_wave_approximation(model,
+                                                                cutoff_freq,
+                                                                return_signal_map=True)
+
+        The following function **is** JAX-transformable:
+
+        .. code-block:: python
+
+            def jax_transformable_func(t):
+                rwa_model_copy = rwa_model.copy()
+                rwa_model_copy.signals = signal_map(new_signals)
+                return rwa_model_copy(t)
+
+        In this way, the outputs of ``rotating_wave_approximation`` can be used in
+        JAX-transformable functions, however ``rotating_wave_approximation`` itself cannot.
+
 
     Formalism: When considering :math:`s_i(t) e^{-tF}G_ie^{tF}`, in the basis in which
     :math:`F` is diagonal, the :math:`(j, k)` element of :math:`G_i` has effective frequency

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -952,12 +952,12 @@ def signal_multiply(sig1: Signal, sig2: Signal) -> SignalSum:
             )
             samples = np.append(new_samples, new_samples_conj, axis=1)
 
-            new_freqs = (sig1.carrier_freq[:, None] + sig2.carrier_freq).flatten()
-            new_freqs_conj = (sig1.carrier_freq - sig2.carrier_freq).flatten()
+            new_freqs = sig1.carrier_freq + sig2.carrier_freq
+            new_freqs_conj = sig1.carrier_freq - sig2.carrier_freq
             freqs = np.append(Array(new_freqs), Array(new_freqs_conj))
 
-            new_phases = (sig1.phase[:, None] + sig2.phase).flatten()
-            new_phases_conj = (sig1.phase[:, None] - sig2.phase).flatten()
+            new_phases = sig1.phase + sig2.phase
+            new_phases_conj = sig1.phase - sig2.phase
             phases = np.append(Array(new_phases), Array(new_phases_conj))
 
             return DiscreteSignalSum(

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -60,8 +60,8 @@ def jax_odeint(
     t_direction = np.sign(Array(t_list[-1] - t_list[0], backend="jax")).data
 
     results = odeint(
-        lambda y, t: t_direction * rhs(t_direction * t, y),
-        y0=y0,
+        lambda y, t: t_direction * Array(rhs(t_direction * t, y)).data,
+        y0=y0.data,
         t=t_direction * t_list.data,
         **kwargs,
     )

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -61,8 +61,8 @@ def jax_odeint(
 
     results = odeint(
         lambda y, t: t_direction * Array(rhs(t_direction * t, y)).data,
-        y0=y0.data,
-        t=t_direction * t_list.data,
+        y0=Array(y0).data,
+        t=t_direction * Array(t_list).data,
         **kwargs,
     )
 

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -57,12 +57,13 @@ def jax_odeint(
     t_list = merge_t_args(t_span, t_eval)
 
     # determine direction of integration
-    t_direction = np.sign(Array(t_list[-1] - t_list[0], backend="jax")).data
+    t_direction = np.sign(Array(t_list[-1] - t_list[0], backend="jax"))
+    rhs = wrap(rhs)
 
     results = odeint(
-        lambda y, t: t_direction * Array(rhs(t_direction * t, y)).data,
-        y0=Array(y0).data,
-        t=t_direction * Array(t_list).data,
+        lambda y, t: rhs(t_direction * t, y) * t_direction,
+        y0=Array(y0),
+        t=t_direction * Array(t_list),
         **kwargs,
     )
 

--- a/qiskit_dynamics/solvers/scipy_solve_ivp.py
+++ b/qiskit_dynamics/solvers/scipy_solve_ivp.py
@@ -77,7 +77,7 @@ def scipy_solve_ivp(
         rhs = real_rhs(rhs)
         y0 = c2r(y0)
 
-    results = solve_ivp(rhs, t_span=t_span.data, y0=y0.data, t_eval=t_eval, method=method, **kwargs)
+    results = solve_ivp(rhs, t_span=t_span, y0=y0.data, t_eval=t_eval, method=method, **kwargs)
     if embed_real:
         results.y = r2c(results.y)
 

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -66,6 +66,13 @@ class Solver:
       :func:`~qiskit_dynamics.models.rotating_wave_approximation`
       for details.
 
+      .. note::
+            When using the ``rwa_cutoff_freq`` optional argument,
+            :class:`~qiskit_dynamics.solvers.solver_classes.Solver` cannot be instantiated within
+            a JAX-transformable function. However, after construction, instances can
+            still be used within JAX-transformable functions regardless of whether an
+            ``rwa_cutoff_freq`` is set.
+
     .. note::
         Modifications to the underlying model after instantiation may be made
         directly via the ``model`` property of this class. However,

--- a/qiskit_dynamics/solvers/solver_functions.py
+++ b/qiskit_dynamics/solvers/solver_functions.py
@@ -111,7 +111,6 @@ def solve_ode(
     ):
         raise QiskitError("Method " + str(method) + " not supported by solve_ode.")
 
-    t_span = Array(t_span)
     y0 = Array(y0)
 
     if isinstance(rhs, BaseGeneratorModel):
@@ -226,7 +225,6 @@ def solve_lmde(
                vectorized evaluation mode."""
         )
 
-    t_span = Array(t_span)
     y0 = Array(y0)
 
     # setup generator and rhs functions to pass to numerical methods

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -37,7 +37,7 @@ def is_lindblad_model_not_vectorized(obj: any) -> bool:
 
 def merge_t_args(
     t_span: Union[List, Tuple, Array], t_eval: Optional[Union[List, Tuple, Array]] = None
-) -> Array:
+) -> Union[List, Tuple, Array]:
     """Merge ``t_span`` and ``t_eval`` into a single array without
     duplicates. Validity of the passed ``t_span`` and ``t_eval``
     follow scipy ``solve_ivp`` validation logic:
@@ -48,19 +48,21 @@ def merge_t_args(
     Note: this is done explicitly with ``numpy``, and hence this is
     not differentiable or compilable using jax.
 
+    If ``t_eval is None`` returns ``t_span`` with no modification.
+
     Args:
         t_span: Interval to solve over.
         t_eval: Time points to include in returned results.
 
     Returns:
-        Array: Combined list of times.
+        Union[List, Tuple, Array]: Combined list of times.
 
     Raises:
         ValueError: If one of several validation checks fail.
     """
 
     if t_eval is None:
-        return Array(t_span)
+        return t_span
 
     t_span = Array(t_span, backend="numpy")
 

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -70,7 +70,7 @@ class TestJaxBase(unittest.TestCase):
             Wrapped and jitted function."""
         wf = wrap(jit, decorator=True)
         # pylint: disable=unnecessary-lambda
-        return wf(lambda *args: func_to_test(*args))
+        return wf(func_to_test)
 
     def jit_grad_wrap(self, func_to_test: Callable) -> Callable:
         """Tests whether a function can be graded. Converts

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -70,7 +70,7 @@ class TestJaxBase(unittest.TestCase):
             Wrapped and jitted function."""
         wf = wrap(jit, decorator=True)
         # pylint: disable=unnecessary-lambda
-        return wf(func_to_test)
+        return wf(wrap(func_to_test))
 
     def jit_grad_wrap(self, func_to_test: Callable) -> Callable:
         """Tests whether a function can be graded. Converts
@@ -82,4 +82,4 @@ class TestJaxBase(unittest.TestCase):
             JIT-compiled gradient of function."""
         wf = wrap(lambda f: jit(grad(f)), decorator=True)
         f = lambda *args: np.sum(func_to_test(*args)).real
-        return wf(f)
+        return wf(wrap(f))

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     pass
 from qiskit_dynamics import dispatch
-from qiskit_dynamics.dispatch import wrap
+from qiskit_dynamics.dispatch import Array, wrap
 
 
 class QiskitDynamicsTestCase(unittest.TestCase):
@@ -32,6 +32,8 @@ class QiskitDynamicsTestCase(unittest.TestCase):
 
     def assertAllClose(self, A, B, rtol=1e-8, atol=1e-8):
         """Call np.allclose and assert true."""
+        A = Array(A)
+        B = Array(B)
         self.assertTrue(np.allclose(A, B, rtol=rtol, atol=atol))
 
 

--- a/test/dynamics/models/test_generator_models.py
+++ b/test/dynamics/models/test_generator_models.py
@@ -514,7 +514,7 @@ class TestGeneratorModelJax(TestGeneratorModel, TestJaxBase):
         """Tests whether all functions are jitable.
         Checks if having a frame makes a difference, as well as
         all jax-compatible evaluation_modes."""
-        self.jit_wrap(self.basic_model.evaluate)(1.)
+        self.jit_wrap(self.basic_model.evaluate)(1.0)
         self.jit_wrap(self.basic_model.evaluate_rhs)(1, Array(np.array([0.2, 0.4])))
 
         self.basic_model.rotating_frame = Array(np.array([[3j, 2j], [2j, 0]]))

--- a/test/dynamics/models/test_generator_models.py
+++ b/test/dynamics/models/test_generator_models.py
@@ -600,8 +600,8 @@ class TestCallableGenerator(QiskitDynamicsTestCase):
 
         # manually evaluate frame
         expected = (
-            i2pi * self.w * U @ self.Z.data @ U.conj().transpose() / 2
-            + d_coeff * i2pi * U @ self.X.data @ U.conj().transpose() / 2
+            i2pi * self.w * U @ self.Z @ U.conj().transpose() / 2
+            + d_coeff * i2pi * U @ self.X @ U.conj().transpose() / 2
             - frame_operator
         )
         self.assertAllClose(value_without_state, expected)

--- a/test/dynamics/models/test_generator_models.py
+++ b/test/dynamics/models/test_generator_models.py
@@ -82,8 +82,8 @@ class TestGeneratorModel(QiskitDynamicsTestCase):
 
         # manually evaluate frame
         expected = (
-            i2pi * self.w * U @ self.Z.data @ U.conj().transpose() / 2
-            + d_coeff * i2pi * U @ self.X.data @ U.conj().transpose() / 2
+            i2pi * self.w * U @ self.Z @ U.conj().transpose() / 2
+            + d_coeff * i2pi * U @ self.X @ U.conj().transpose() / 2
             - frame_operator
         )
 

--- a/test/dynamics/models/test_generator_models.py
+++ b/test/dynamics/models/test_generator_models.py
@@ -21,7 +21,7 @@ from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
 from qiskit_dynamics.models import CallableGenerator, GeneratorModel, RotatingFrame
 from qiskit_dynamics.signals import Signal, SignalList
-from qiskit_dynamics.dispatch import Array
+from qiskit_dynamics.dispatch import Array, wrap
 from ..common import QiskitDynamicsTestCase, TestJaxBase
 
 
@@ -109,7 +109,7 @@ class TestGeneratorModel(QiskitDynamicsTestCase):
         self.basic_model.rotating_frame = frame_op
 
         # get the frame basis that is used in model
-        _, U = np.linalg.eigh(1j * frame_op)
+        _, U = wrap(np.linalg.eigh)(1j * frame_op)
 
         t = 3.21412
         value = self.basic_model(t, in_frame_basis=True)
@@ -311,7 +311,7 @@ class TestGeneratorModel(QiskitDynamicsTestCase):
 
         farr = Array(np.array([[3j, 2j], [2j, 0]]))
         farr2 = Array(np.array([[1j, 2], [-2, 3j]]))
-        evals, evect = np.linalg.eig(farr)
+        evals, evect = wrap(np.linalg.eig)(farr)
         diafarr = np.diag(evals)
 
         paulis_in_frame_basis = np.conjugate(np.transpose(evect)) @ paulis @ evect
@@ -403,7 +403,7 @@ class TestGeneratorModel(QiskitDynamicsTestCase):
         t = 2
 
         farr = Array(np.array([[3j, 2j], [2j, 0]]))
-        evals, evect = np.linalg.eig(farr)
+        evals, evect = wrap(np.linalg.eig)(farr)
         diafarr = np.diag(evals)
 
         paulis_in_frame_basis = np.conjugate(np.transpose(evect)) @ paulis @ evect
@@ -514,7 +514,7 @@ class TestGeneratorModelJax(TestGeneratorModel, TestJaxBase):
         """Tests whether all functions are jitable.
         Checks if having a frame makes a difference, as well as
         all jax-compatible evaluation_modes."""
-        self.jit_wrap(self.basic_model.evaluate)(1)
+        self.jit_wrap(self.basic_model.evaluate)(1.)
         self.jit_wrap(self.basic_model.evaluate_rhs)(1, Array(np.array([0.2, 0.4])))
 
         self.basic_model.rotating_frame = Array(np.array([[3j, 2j], [2j, 0]]))

--- a/test/dynamics/models/test_hamiltonian_model.py
+++ b/test/dynamics/models/test_hamiltonian_model.py
@@ -75,8 +75,8 @@ class TestHamiltonianModel(QiskitDynamicsTestCase):
 
         # manually evaluate frame
         expected = (
-            twopi * self.w * U @ self.Z.data @ U.conj().transpose() / 2
-            + d_coeff * twopi * U @ self.X.data @ U.conj().transpose() / 2
+            twopi * self.w * U @ self.Z @ U.conj().transpose() / 2
+            + d_coeff * twopi * U @ self.X @ U.conj().transpose() / 2
             - frame_operator
         )
 

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -462,7 +462,7 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         self.assertAllClose(op1, op2.reshape((6, 6), order="F"))
 
 
-class TestFrameJax(TestRotatingFrame, TestJaxBase):
+class TestRotatingFrameJax(TestRotatingFrame, TestJaxBase):
     """Jax version of TestRotatingFrame tests.
 
     Note: This class has more tests due to inheritance.
@@ -484,3 +484,19 @@ class TestFrameJax(TestRotatingFrame, TestJaxBase):
 
         rotating_frame = RotatingFrame(self.Z + 1j * self.X)
         self.assertTrue(jnp.isnan(rotating_frame.frame_diag[0]))
+
+    def test_jitting(self):
+        """Test jitting of state_into_frame and _conjugate_and_add."""
+
+        rotating_frame = RotatingFrame(Array([1., -1.]))
+
+        self.jit_wrap(rotating_frame.state_into_frame)(t=0.1, y=np.array([0., 1.]))
+        self.jit_wrap(rotating_frame._conjugate_and_add)(t=0.1, y=np.array([[0., 1.], [1., 0.]]))
+
+    def test_jit_and_grad(self):
+        """Test jitting and gradding of state_into_frame and _conjugate_and_add."""
+
+        rotating_frame = RotatingFrame(Array([1., -1.]))
+
+        self.jit_grad_wrap(rotating_frame.state_into_frame)(t=0.1, y=np.array([0., 1.]))
+        self.jit_grad_wrap(rotating_frame._conjugate_and_add)(t=0.1, y=np.array([[0., 1.], [1., 0.]]))

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -488,15 +488,19 @@ class TestRotatingFrameJax(TestRotatingFrame, TestJaxBase):
     def test_jitting(self):
         """Test jitting of state_into_frame and _conjugate_and_add."""
 
-        rotating_frame = RotatingFrame(Array([1., -1.]))
+        rotating_frame = RotatingFrame(Array([1.0, -1.0]))
 
-        self.jit_wrap(rotating_frame.state_into_frame)(t=0.1, y=np.array([0., 1.]))
-        self.jit_wrap(rotating_frame._conjugate_and_add)(t=0.1, operator=np.array([[0., 1.], [1., 0.]]))
+        self.jit_wrap(rotating_frame.state_into_frame)(t=0.1, y=np.array([0.0, 1.0]))
+        self.jit_wrap(rotating_frame._conjugate_and_add)(
+            t=0.1, operator=np.array([[0.0, 1.0], [1.0, 0.0]])
+        )
 
     def test_jit_and_grad(self):
         """Test jitting and gradding of state_into_frame and _conjugate_and_add."""
 
-        rotating_frame = RotatingFrame(Array([1., -1.]))
+        rotating_frame = RotatingFrame(Array([1.0, -1.0]))
 
-        self.jit_grad_wrap(lambda t, y: rotating_frame.state_into_frame(t, y))(0.1, np.array([0., 1.]))
-        self.jit_grad_wrap(lambda t, y: rotating_frame._conjugate_and_add(t, y))(0.1, np.array([[0., 1.], [1., 0.]]))
+        self.jit_grad_wrap(rotating_frame.state_into_frame)(0.1, np.array([0.0, 1.0]))
+        self.jit_grad_wrap(rotating_frame._conjugate_and_add)(
+            0.1, np.array([[0.0, 1.0], [1.0, 0.0]])
+        )

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -491,12 +491,12 @@ class TestRotatingFrameJax(TestRotatingFrame, TestJaxBase):
         rotating_frame = RotatingFrame(Array([1., -1.]))
 
         self.jit_wrap(rotating_frame.state_into_frame)(t=0.1, y=np.array([0., 1.]))
-        self.jit_wrap(rotating_frame._conjugate_and_add)(t=0.1, y=np.array([[0., 1.], [1., 0.]]))
+        self.jit_wrap(rotating_frame._conjugate_and_add)(t=0.1, operator=np.array([[0., 1.], [1., 0.]]))
 
     def test_jit_and_grad(self):
         """Test jitting and gradding of state_into_frame and _conjugate_and_add."""
 
         rotating_frame = RotatingFrame(Array([1., -1.]))
 
-        self.jit_grad_wrap(rotating_frame.state_into_frame)(t=0.1, y=np.array([0., 1.]))
-        self.jit_grad_wrap(rotating_frame._conjugate_and_add)(t=0.1, y=np.array([[0., 1.], [1., 0.]]))
+        self.jit_grad_wrap(lambda t, y: rotating_frame.state_into_frame(t, y))(0.1, np.array([0., 1.]))
+        self.jit_grad_wrap(lambda t, y: rotating_frame._conjugate_and_add(t, y))(0.1, np.array([[0., 1.], [1., 0.]]))

--- a/test/dynamics/models/test_rotating_wave_approximation.py
+++ b/test/dynamics/models/test_rotating_wave_approximation.py
@@ -149,21 +149,25 @@ class TestRotatingWave(QiskitDynamicsTestCase):
 
 
 class TestRotatingWaveJax(TestRotatingWave, TestJaxBase):
-    """Jax version of TestRotatingWave tests.
+    """Jax version of TestRotatingWave tests."""
 
-    Note: This class has no body but contains tests due to inheritance.
-    """
+    def test_jitable_gradable_signal_map(self):
+        """Tests that signal_map from the RWA is jitable and gradable."""
 
-    def test_jitable_gradable_rwa(self):
-        """Tests whether a function involving the RWA is jitable and gradable."""
+        sample_sigs = [Signal(1.0, 0.0), Signal(1.0, -3.0), Signal(1.0, 1.0), Signal(1.0, 3.0)]
+        ops = Array(np.ones((4, 2, 2)))
+        drift = Array(np.ones((2, 2)))
+        model = GeneratorModel(ops, signals=sample_sigs, drift=drift, rotating_frame=drift)
+        rwa_model, signal_map = rotating_wave_approximation(
+            model=model, cutoff_freq=2.0, return_signal_map=True
+        )
 
-        def _simple_function_using_rwa(w):
+        def _simple_function_using_rwa(t, w):
             """Simple function that involves taking the rotating wave approximation."""
-            sigs = [Signal(1, 0), Signal(lambda t: w * t, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
-            ops = Array(np.ones((4, 2, 2)))
-            dft = Array(np.ones((2, 2)))
-            GM = GeneratorModel(ops, signals=sigs, drift=dft, rotating_frame=None)
-            return rotating_wave_approximation(GM, 2)(2)
+            sigs = [Signal(1, 0), Signal(lambda s: w * s, -3, 0), Signal(1, 1), Signal(1, 3, 0)]
+            rwa_model_copy = rwa_model.copy()
+            rwa_model_copy.signals = signal_map(sigs)
+            return rwa_model(t)
 
-        self.jit_wrap(_simple_function_using_rwa)(1.0)
-        self.jit_grad_wrap(_simple_function_using_rwa)(1.0)
+        self.jit_wrap(_simple_function_using_rwa)(1.0, 1.0)
+        self.jit_grad_wrap(_simple_function_using_rwa)(1.0, 1.0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixing testing errors as a result of JAX update.

Current changes:
- Added `Array` wrapping to args of `assertAllClose` in the base test class. `jax.numpy` will now raise errors if things like lists are passed into most functions, so this wrapping is now necessary.
- Removed automatic array wrapping for `t_span` in `solve_lmde` and `solve_ode`. This fixed tests in `test_jax_transformations` which utilize these function. JAX is I think now more aggressive with turning things into tracers, and in these tests we were expecting these to be static. This wrapping was totally superfluous anyway as each solver handled things on its own.
    - This fixed some errors but broke other things - turns out it was due to some underlying solver functions assuming `t_span` was an `Array`, so they did `t_span.data` automatically. Removed those and those errors are fixed.
- There is a problem with the `dispatch.wrap` - not sure what it is. I was able to fix some tests by modifying the `jax_odeint` function so that everything passed to the jax solver is either a JAX array (not an `Array`) or only returns jax arrays.
     - Edit: This statement is wrong but keeping it here because we may want to undo these changes later.