### PR TITLE
Update wrap function to avoid conditional checks

### DIFF
--- a/qiskit_dynamics/dispatch/wrap.py
+++ b/qiskit_dynamics/dispatch/wrap.py
@@ -18,70 +18,6 @@ from typing import Callable
 from .array import Array
 
 
-class WrappedFunction:
-    """Class for storing wrapped array backend functions to work with Arrays."""
-
-    def __init__(
-        self,
-        func: Callable,
-        wrap_return: bool = True,
-        wrap_args: bool = True,
-        decorator: bool = False,
-    ):
-        """Wrap an array backend function to work with Arrays.
-
-        Args:
-            func: a function to wrap.
-            wrap_return: If ``True`` convert results that are registered array
-                        backend types into Array objects (Default: True).
-            wrap_args: If ``True`` also wrap function type args and kwargs of the
-                   wrapped function.
-            decorator: If ``True`` the wrapped decorator function ``func`` will
-                    also wrap the decorated functions (Default: False).
-        """
-        self._func = func
-        self._wrap_return = wrap_return
-        self._wrap_args = wrap_args
-        self._decorator = decorator
-
-        if decorator:
-            self._wrapped_func = _wrap_decorator(func, wrap_return=wrap_return, wrap_args=wrap_args)
-        else:
-            self._wrapped_func = _wrap_function(func, wrap_return=wrap_return, wrap_args=wrap_args)
-
-    def __call__(self, *args, **kwargs):
-        """Evaluate the wrapped function."""
-        return self._wrapped_func(*args, **kwargs)
-
-    def __repr__(self):
-        ret = "WrappedFunction"
-        ret += f"\n decorator: {self._decorator}"
-        ret += f"\n wrap_return: {self._wrap_return}"
-        ret += f"\n wrap_args: {self._wrap_args}"
-        ret += f"\n func: {repr(self._func)}"
-        return ret
-
-    @property
-    def func(self):
-        """The original function."""
-        return self._func
-
-    @property
-    def decorator(self):
-        """Return if the wrapped function is a decorator."""
-        return self._decorator
-
-    @property
-    def wrap_return(self):
-        """Return if the wrapped function's return is also wrapped as an Arrays"""
-        return self._wrap_return
-
-    @property
-    def wrap_args(self):
-        """Return if the wrapped function also has recursively wrapped args and kwargs"""
-        return self._wrap_return
-
-
 def wrap(
     func: Callable, wrap_return: bool = True, wrap_args: bool = True, decorator: bool = False
 ) -> Callable:
@@ -97,9 +33,12 @@ def wrap(
                    also wrap the decorated functions (Default: False).
 
     Returns:
-        WrappedFunction: The wrapped function.
+        Callable: The wrapped function.
     """
-    return WrappedFunction(func, wrap_return=wrap_return, decorator=decorator, wrap_args=wrap_args)
+    if decorator:
+        return _wrap_decorator(func, wrap_return=wrap_return, wrap_args=wrap_args)
+    else:
+        return _wrap_function(func, wrap_return=wrap_return, wrap_args=wrap_args)
 
 
 def _wrap_array_function(func: Callable) -> Callable:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This updates the `dispatch.wrap` function to avoid conditional checks within the function defs of the wrapped functions it returns when possible. It also adds an extra kwarg to `wrap` that allows disabling the recursive wrapping of function arguments (which is enabled by default). Disabling this may also give performance improvements for compatible functions.

### Details and comments


Originally the hope was to return wrapped functions as a class instance with a call method that could be inspected to return the original function, and details about the wrapped, however this caused several tests to fail that used jax jit and grad functions on model evaluation. 

I'm not sure how to fix this so just added in the refactor code for the wrapped functions to move the conditional checks outside the function definitions instead. This increases the verbosity of the source code, but should help improve performance if these wrapped functions are ever called in a performance intensive loop since the functions themselves do less conditional checking.