### PR TITLE
Move dispatch functions to Array methods

### DIFF
--- a/docs/tutorials/optimizing_pulse_sequence.rst
+++ b/docs/tutorials/optimizing_pulse_sequence.rst
@@ -20,7 +20,7 @@ the following steps:
 -----------------------
 
 First, set JAX to operate in 64-bit mode, and set JAX as the default
-backend using ``qiskit-dynamics.dispatch`` for performing array operations.
+backend using ``Array`` for performing array operations.
 This is necessary to enable automatic differentiation of the Qiskit Dynamics code
 in this tutorial. See the user guide entry on using JAX
 for a more detailed explanation of why this step is necessary.
@@ -33,8 +33,8 @@ for a more detailed explanation of why this step is necessary.
     # tell JAX we are using CPU
     jax.config.update('jax_platform_name', 'cpu')
 
-    from qiskit_dynamics import dispatch
-    dispatch.set_default_backend('jax')
+    from qiskit_dynamics.array import Array
+    Array.set_default_backend('jax')
 
 2. Setup the solver
 -------------------

--- a/docs/userguide/how_to_use_jax.rst
+++ b/docs/userguide/how_to_use_jax.rst
@@ -3,7 +3,7 @@ How-to use JAX with ``qiskit-dynamics``
 
 JAX enables just-in-time compilation, automatic differentation, and GPU
 execution. JAX is integrated into ``qiskit-dynamics`` via the
-``dispatch`` submodule, which allows most parts of the package to be
+``Array`` class, which allows most parts of the package to be
 executed with either ``numpy`` or ``jax.numpy``.
 
 This guide addresses the following topics:
@@ -18,7 +18,7 @@ This guide addresses the following topics:
 1. How do I configure dynamics to run with JAX?
 -----------------------------------------------
 
-The ``dispatch`` submodule provides a means of controlling whether array
+The ``Array`` class provides a means of controlling whether array
 operations are performed using ``numpy`` or ``jax.numpy``. In many
 cases, the “default backend” is used to determine which of the two
 options is used.
@@ -32,19 +32,19 @@ options is used.
     # tell JAX we are using CPU
     jax.config.update('jax_platform_name', 'cpu')
 
-    # import dispatch and set default backend
-    from qiskit_dynamics import dispatch
-    dispatch.set_default_backend('jax')
+    # import Array and set default backend
+    from qiskit_dynamics.array import Array
+    Array.set_default_backend('jax')
 
 The default backend can be observed via:
 
 .. jupyter-execute::
 
-    dispatch.default_backend()
+    Array.default_backend()
 
 
-2. How do I write code using dispatch that can be executed with either ``numpy`` or JAX?
-----------------------------------------------------------------------------------------
+2. How do I write code using Array that can be executed with either ``numpy`` or JAX?
+-------------------------------------------------------------------------------------
 
 The ``Array`` class wraps both ``numpy`` and ``jax.numpy``
 arrays. The particular type is indicated by the ``backend`` property,
@@ -65,7 +65,7 @@ JAX-transformable functions must be:
   - Pure, in the sense that they have no side-effects.
 
 The previous section shows how to handle the first two points using
-``dispatch`` and ``Array``. The last point further restricts the type of
+``Array``. The last point further restricts the type of
 code that can be safely transformed. Qiskit Dynamics uses various objects which
 can be updated by setting properties (models, solvers). If a function to
 be transformed requires updating an already-constructed object of this

--- a/qiskit_dynamics/array/array.py
+++ b/qiskit_dynamics/array/array.py
@@ -14,7 +14,7 @@
 import copy
 from functools import wraps
 from types import BuiltinMethodType, MethodType
-from typing import Optional, Union, Tuple
+from typing import Optional, Union, Tuple, Set
 from numbers import Number
 
 import numpy
@@ -106,6 +106,23 @@ class Array(NDArrayOperatorsMixin):
         Dispatch.validate_backend(value)
         self._data = asarray(self._data, backend=value)
         self._backend = value
+
+    @classmethod
+    def set_default_backend(cls, backend: Union[str, None]):
+        """Set the default array backend."""
+        if backend is not None:
+            Dispatch.validate_backend(backend)
+        Dispatch.DEFAULT_BACKEND = backend
+
+    @classmethod
+    def default_backend(cls) -> str:
+        """Return the default array backend."""
+        return Dispatch.DEFAULT_BACKEND
+
+    @classmethod
+    def available_backends(cls) -> Set[str]:
+        """Return a tuple of available array backends"""
+        return Dispatch.REGISTERED_BACKENDS
 
     def __repr__(self):
         prefix = "Array("

--- a/qiskit_dynamics/dispatch/__init__.py
+++ b/qiskit_dynamics/dispatch/__init__.py
@@ -29,26 +29,12 @@ Dispatch Functions
 .. autosummary::
     :toctree: ../stubs/
 
-    set_default_backend
-    default_backend
-    available_backends
-    backend_types
     asarray
     requires_backend
 """
 
-# Import Array
-from .array import Array
-
-# Import wrapper function
-from .wrap import wrap
-
 # Import dispatch utilities
 from .dispatch import (
-    set_default_backend,
-    default_backend,
-    available_backends,
-    backend_types,
     asarray,
     requires_backend,
 )
@@ -56,6 +42,13 @@ from .dispatch import (
 # Register backends
 from .backends import *
 
-# If only one backend is available, set it as the default
-if len(available_backends()) == 1:
-    set_default_backend(available_backends()[0])
+
+# DEPRECATED imports
+from .dispatch import (
+    set_default_backend,
+    default_backend,
+    available_backends,
+    backend_types,
+)
+from .array import Array
+from .wrap import wrap

--- a/qiskit_dynamics/dispatch/backends/__init__.py
+++ b/qiskit_dynamics/dispatch/backends/__init__.py
@@ -13,3 +13,11 @@
 
 from .numpy import *
 from .jax import *
+
+# Set default backend if only 1 is available
+from ..dispatch import Dispatch
+
+if len(Dispatch.REGISTERED_BACKENDS) == 1:
+    Dispatch.DEFAULT_BACKEND = Dispatch.REGISTERED_BACKENDS[0]
+
+__all__ = []

--- a/qiskit_dynamics/dispatch/dispatch.py
+++ b/qiskit_dynamics/dispatch/dispatch.py
@@ -293,7 +293,7 @@ def default_backend():
 
 
 @deprecate_function(
-    "The `backend_types` function has been depreacted and will be removed next release."
+    "The `backend_types` function has been deprecated and will be removed next release."
 )
 def backend_types():
     """Return tuple of array backend types"""

--- a/qiskit_dynamics/dispatch/dispatch.py
+++ b/qiskit_dynamics/dispatch/dispatch.py
@@ -273,7 +273,7 @@ class Dispatch:
 
 # Public functions
 @deprecate_function(
-    "The `set_default_backend` function has been depreacted and will be removed "
+    "The `set_default_backend` function has been deprecated and will be removed "
     "next release. Use the class method `Array.set_default_backend(backend)` instead."
 )
 def set_default_backend(backend: Optional[str] = None):

--- a/qiskit_dynamics/dispatch/dispatch.py
+++ b/qiskit_dynamics/dispatch/dispatch.py
@@ -301,7 +301,7 @@ def backend_types():
 
 
 @deprecate_function(
-    "The `available_backends` function has been depreacted and will be removed next"
+    "The `available_backends` function has been deprecated and will be removed next"
     "release. Use the class method `Array.available_backends()` instead."
 )
 def available_backends():

--- a/qiskit_dynamics/dispatch/dispatch.py
+++ b/qiskit_dynamics/dispatch/dispatch.py
@@ -284,7 +284,7 @@ def set_default_backend(backend: Optional[str] = None):
 
 
 @deprecate_function(
-    "The `default_backend` function has been depreacted and will be removed next "
+    "The `default_backend` function has been deprecated and will be removed next "
     "release. Use the class method `Array.default_backend()` instead."
 )
 def default_backend():

--- a/qiskit_dynamics/dispatch/dispatch.py
+++ b/qiskit_dynamics/dispatch/dispatch.py
@@ -14,6 +14,7 @@
 import functools
 from types import FunctionType
 from typing import Optional, Union, Tuple, Callable
+from qiskit.utils import deprecate_function
 from .exceptions import DispatchError
 
 
@@ -271,25 +272,36 @@ class Dispatch:
 
 
 # Public functions
-
-
+@deprecate_function(
+    "The `set_default_backend` function has been depreacted and will be removed "
+    "next release. Use the class method `Array.set_default_backend(backend)` instead."
+)
 def set_default_backend(backend: Optional[str] = None):
     """Set the default array backend."""
-    if backend is not None:
-        Dispatch.validate_backend(backend)
     Dispatch.DEFAULT_BACKEND = backend
 
 
+@deprecate_function(
+    "The `default_backend` function has been depreacted and will be removed next "
+    "release. Use the class method `Array.default_backend()` instead."
+)
 def default_backend():
     """Return the default array backend."""
     return Dispatch.DEFAULT_BACKEND
 
 
+@deprecate_function(
+    "The `backend_types` function has been depreacted and will be removed next release."
+)
 def backend_types():
     """Return tuple of array backend types"""
     return Dispatch.REGISTERED_TYPES
 
 
+@deprecate_function(
+    "The `available_backends` function has been depreacted and will be removed next"
+    "release. Use the class method `Array.available_backends()` instead."
+)
 def available_backends():
     """Return a tuple of available array backends"""
     return Dispatch.REGISTERED_BACKENDS

--- a/qiskit_dynamics/dispatch/dispatch.py
+++ b/qiskit_dynamics/dispatch/dispatch.py
@@ -348,7 +348,7 @@ def requires_backend(backend: str) -> Callable:
         """Specify that the decorated object requires a specifc Array backend."""
 
         def check_backend(descriptor):
-            if backend not in available_backends():
+            if backend not in Dispatch.REGISTERED_BACKENDS:
                 raise DispatchError(
                     f"Array backend '{backend}' required by {descriptor} "
                     "is not installed. Please install the optional "

--- a/qiskit_dynamics/dispatch/dispatch.py
+++ b/qiskit_dynamics/dispatch/dispatch.py
@@ -278,6 +278,8 @@ class Dispatch:
 )
 def set_default_backend(backend: Optional[str] = None):
     """Set the default array backend."""
+    if backend is not None:
+        Dispatch.validate_backend(backend)
     Dispatch.DEFAULT_BACKEND = backend
 
 

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -21,7 +21,6 @@ from scipy.sparse.csr import csr_matrix
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
-from qiskit_dynamics import dispatch
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.type_utils import to_numeric_matrix_type
 from qiskit_dynamics.signals import Signal, SignalList
@@ -655,7 +654,7 @@ def construct_lindblad_operator_collection(
 
     # raise warning if sparse mode set with JAX not on cpu
     if (
-        dispatch.default_backend() == "jax"
+        Array.default_backend() == "jax"
         and "sparse" in evaluation_mode
         and jax.default_backend() != "cpu"
     ):
@@ -667,14 +666,14 @@ def construct_lindblad_operator_collection(
     if evaluation_mode == "dense":
         CollectionClass = DenseLindbladCollection
     elif evaluation_mode == "sparse":
-        if dispatch.default_backend() == "jax":
+        if Array.default_backend() == "jax":
             CollectionClass = JAXSparseLindbladCollection
         else:
             CollectionClass = SparseLindbladCollection
     elif evaluation_mode == "dense_vectorized":
         CollectionClass = DenseVectorizedLindbladCollection
     elif evaluation_mode == "sparse_vectorized":
-        if dispatch.default_backend() == "jax":
+        if Array.default_backend() == "jax":
             CollectionClass = JAXSparseVectorizedLindbladCollection
         else:
             CollectionClass = SparseVectorizedLindbladCollection

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -30,7 +30,6 @@ except ImportError:
     pass
 
 from qiskit import QiskitError
-from qiskit_dynamics import dispatch
 from qiskit_dynamics.array import Array
 
 
@@ -106,7 +105,7 @@ class Signal:
             else:
                 self._envelope = lambda t: envelope * np.ones_like(t)
         elif callable(envelope):
-            if dispatch.default_backend() == "jax":
+            if Array.default_backend() == "jax":
                 self._envelope = lambda t: Array(envelope(t))
             else:
                 self._envelope = envelope
@@ -569,7 +568,7 @@ class SignalSum(SignalCollection, Signal):
         SignalCollection.__init__(self, components)
 
         # set up routine for evaluating envelopes if jax
-        if dispatch.default_backend() == "jax":
+        if Array.default_backend() == "jax":
             jax_arraylist_eval = array_funclist_evaluate([sig.envelope for sig in self.components])
 
             def envelope(t):
@@ -594,7 +593,7 @@ class SignalSum(SignalCollection, Signal):
 
     def complex_value(self, t: Union[float, np.array, Array]) -> Union[complex, np.array, Array]:
         """Return the sum of the complex values of each component."""
-        if dispatch.default_backend() == "jax":
+        if Array.default_backend() == "jax":
             t = Array(t)
         exp_phases = np.exp(np.expand_dims(t, -1) * self._carrier_arg + self._phase_arg)
         return np.sum(self.envelope(t) * exp_phases, axis=-1)
@@ -812,7 +811,7 @@ class SignalList(SignalCollection):
         super().__init__(signal_list)
 
         # setup complex value and full signal evaluation
-        if dispatch.default_backend() == "jax":
+        if Array.default_backend() == "jax":
             self._eval_complex_value = array_funclist_evaluate(
                 [sig.complex_value for sig in self.components]
             )

--- a/qiskit_dynamics/type_utils.py
+++ b/qiskit_dynamics/type_utils.py
@@ -26,7 +26,6 @@ from scipy.sparse import identity as sparse_identity
 from scipy.sparse.csr import csr_matrix
 
 from qiskit.quantum_info.operators import Operator
-from qiskit_dynamics import dispatch
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.dispatch import requires_backend
 
@@ -371,7 +370,7 @@ def to_array(op: Union[Operator, Array, List[Operator], List[Array], spmatrix], 
         return op
 
     if isinstance(op, np.ndarray) and op.dtype != "O":
-        if dispatch.default_backend() in [None, "numpy"]:
+        if Array.default_backend() in [None, "numpy"]:
             return op
         else:
             return Array(op)

--- a/releasenotes/notes/array-methods-67a41ffdba2e86c3.yaml
+++ b/releasenotes/notes/array-methods-67a41ffdba2e86c3.yaml
@@ -1,0 +1,25 @@
+---
+features:
+  - |
+    Adds new :class:`~qiskit_dynamics.array.Array` class methods
+    :meth:`~qiskit_dynamics.array.Array.default_backend`,
+    :meth:`~qiskit_dynamics.array.Array.set_default_backend`,
+    :meth:`~qiskit_dynamics.array.Array.available_backends` which implement
+    the functionality of the previous methods of the same name from the
+    dispatch module.
+deprecations:
+  - |
+    The :func:`qiskit_dynamics.dispatch.default_backend` function has been
+    deprecated and will be removed in 0.3.0 release. It has been replaced by
+    the :meth:`qiskit_dynamics.array.Array.default_backend` class method.
+  - |
+    The :func:`qiskit_dynamics.dispatch.set_default_backend` function has been
+    deprecated and will be removed in 0.3.0 release. It has been replaced by
+    the :meth:`qiskit_dynamics.array.Array.set_default_backend` class method.
+  - |
+    The :func:`qiskit_dynamics.dispatch.available_backends` function has been
+    deprecatedand will be removed in 0.3.0 release. It has been replaced by
+    the :meth:`qiskit_dynamics.array.Array.available_backends` class method.
+  - |
+    The :func:`qiskit_dynamics.dispatch.backend_types` function has been
+    deprecated as it is no longer needed.

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     pass
 
-from qiskit_dynamics import dispatch
 from qiskit_dynamics.array import Array, wrap
 
 
@@ -72,12 +71,12 @@ class TestJaxBase(unittest.TestCase):
         except Exception as err:
             raise unittest.SkipTest("Skipping jax tests.") from err
 
-        dispatch.set_default_backend("jax")
+        Array.set_default_backend("jax")
 
     @classmethod
     def tearDownClass(cls):
         """Set numpy back to the default backend."""
-        dispatch.set_default_backend("numpy")
+        Array.set_default_backend("numpy")
 
     def jit_wrap(self, func_to_test: Callable) -> Callable:
         """Wraps and jits func_to_test.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This moves the dispatch functions for setting and getting the default backend to the class methods of `Array`. This means that none of our docs or internal code other than the `Array` class need to directly use the dispatch module. 

This deprecates the moved functions from that module in anticipation of replacing this module with an improved dispatch system.

### Details and comments
