### PR TITLE
Fix CI by adjusting requirements-dev.txt pinning

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 stestr>=3.0.0
 astroid==2.5
 pylint==2.7.1
-black
+black==21.11b1
 qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints
 jupyter-sphinx
@@ -9,4 +9,4 @@ pygments>=2.4
 reno>=3.4.0
 nbsphinx
 qutip
-matplotlib<3.5
+matplotlib>=3.3.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Qiskit Terra 0.19.0 released recently which changed the required
matplotlib minimum version and we no longer need to cap < 3.5. To
unblock CI this commit fixes this issue. The other issue with our
dev requirements is we were running black unpinned. Black explicitly
changes the output formatting between releases and if we're relying on
it for CI testing we need to use a fixed version so that CI and local
testing are always using the same version. A recent black release
changed the formatting and broke CI as it expects a different output
formatting than what is in the repo currently. This commit pins the
version to the last working release and we'll just use that version
moving forward until we have a reason to upgrade and update the
formatting in the repo.

### Details and comments


