### PR TITLE
Fixing errors introduced by recent JAX release

### DIFF
--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -419,9 +419,7 @@ class LindbladModel(BaseGeneratorModel):
             density matrix by left-multiplication. Allows for direct evaluate generator.
          * 'sparse': Like dense, but matrices stored in sparse format. If the default Array backend
             is JAX, uses JAX BCOO sparse arrays, otherwise uses scipy
-            :class:`csr_matrix` sparse type. Note that reverse mode automatic differentiation
-            does not work in sparse mode when default backend is JAX, use forward mode instead.
-            Note that JAX sparse mode is only recommended for use on CPU.
+            :class:`csr_matrix` sparse type.
          * `sparse_vectorized`: Like dense_vectorized, but matrices stored in sparse format.
             If the default Array backend is JAX, uses JAX BCOO sparse arrays, otherwise uses scipy
             :class:`csr_matrix` sparse type. Note that

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -36,6 +36,7 @@ try:
 
     def jsparse_linear_combo(coeffs, mats):
         """Method for computing a linear combination of sparse arrays."""
+        #pylint: disable=unexpected-keyword-arg
         return jsparse_sum(jnp.broadcast_to(coeffs[:, None, None], mats.shape) * mats, axis=0)
 
     # sparse version of computing A @ X @ B

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -36,7 +36,7 @@ try:
 
     def jsparse_linear_combo(coeffs, mats):
         """Method for computing a linear combination of sparse arrays."""
-        #pylint: disable=unexpected-keyword-arg
+        # pylint: disable=unexpected-keyword-arg
         return jsparse_sum(jnp.broadcast_to(coeffs[:, None, None], mats.shape) * mats, axis=0)
 
     # sparse version of computing A @ X @ B

--- a/qiskit_dynamics/models/rotating_wave_approximation.py
+++ b/qiskit_dynamics/models/rotating_wave_approximation.py
@@ -198,6 +198,7 @@ def rotating_wave_approximation(
         if cur_static_dis is not None:
             rwa_static_dis = []
             for op in cur_static_dis:
+                op = Array(op)
                 rwa_op = op * (abs(frame_freqs) < cutoff_freq).astype(int)
                 rwa_op = model.rotating_frame.operator_out_of_frame_basis(rwa_op)
                 rwa_static_dis.append(rwa_op)

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -349,7 +349,10 @@ def initial_state_converter(
 
 
 def final_state_converter(obj: Any, cls: Optional[Type] = None) -> Any:
-    """Convert final state Array to custom class.
+    """Convert final state Array to custom class. If ``cls`` is not ``None``,
+    will explicitly convert ``obj`` into a ``numpy.array`` before wrapping,
+    under the assumption that ``cls`` will be a ``qiskit.quantum_info`` type,
+    which only support ``numpy.array``s.
 
     Args:
         obj: final state Array.
@@ -361,7 +364,4 @@ def final_state_converter(obj: Any, cls: Optional[Type] = None) -> Any:
     if cls is None:
         return obj
 
-    if issubclass(cls, (BaseOperator, QuantumState)) and isinstance(obj, Array):
-        return cls(obj.data)
-
-    return cls(obj)
+    return cls(np.array(obj))

--- a/releasenotes/notes/0.2/0.2.1-patch-eb5b64e5ea68d953.yaml
+++ b/releasenotes/notes/0.2/0.2.1-patch-eb5b64e5ea68d953.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    Increased minimum jax and jaxlib versions for better sparse support, enabling
+    reverse mode automatic differentiation of :class:`qiskit_dynamics.models.LindbladModel`.
+fixes:
+  - |
+    Fixes a bug where simulations could raise an error using JAX solvers for
+    Statevector and DensityMatrix initial states.

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ requirements = [
     "qiskit-terra>=0.16.0",
 ]
 
-jax_extras = ['jax>=0.2.19',
-              'jaxlib>=0.1.70']
+jax_extras = ['jax>=0.2.26',
+              'jaxlib>=0.1.75']
 
 PACKAGES = setuptools.find_packages(exclude=['test*'])
 

--- a/test/dynamics/models/test_lindblad_model.py
+++ b/test/dynamics/models/test_lindblad_model.py
@@ -657,26 +657,6 @@ class TestLindbladModelSparse(TestLindbladModel):
 class TestLindbladModelJAXSparse(TestLindbladModelSparse, TestLindbladModelJax):
     """JAX sparse-mode tests."""
 
-    def test_gradable_funcs(self):
-        """Override base class to test forward mode differentiability,
-        as current implementation only allows for this.
-        """
-
-        from jax import jacfwd, jit
-
-        def func_to_grad(t, y):
-            t = Array(t).data
-            y = Array(y).data
-            return Array(self.basic_lindblad.evaluate_rhs(t, y)).data
-
-        jacfwd_func = jit(jacfwd(func_to_grad))
-        jacfwd_func(1.0, np.array([[0.2, 0.4], [0.6, 0.8]]))
-
-        # set rotating frame after construction and re-grad the function
-        self.basic_lindblad.rotating_frame = Array(np.array([[3j, 2j], [2j, 0]]))
-        jacfwd_func = jit(jacfwd(func_to_grad))
-        jacfwd_func(1.0, np.array([[0.2, 0.4], [0.6, 0.8]]))
-
 
 class TestLindbladModelDenseVectorized(TestLindbladModel):
     """Test class for dense vectorized mode operation of LindbladModel."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Needed to add additional `Array` wrapping in one spot in `rotating_wave_approximation` in which a raw JAX array was controlling a binary operation.

Also, in `final_state_converter`, JAX arrays were being fed into quantum info types, e.g. `DensityMatrix`, raising an error. I've changed this function to always convert the array to a `numpy.array` before wrapping in `cls`, as `cls` will always be a quantum info type, which can only accept `numpy.array`s in any case. The doc string for this function has been updated to explain this.
