### PR TITLE
Removing getting started link and fixing tutorials link

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -88,12 +88,12 @@
 
       <div class="main-menu">
         <ul>
-          <li {%- if pagename == 'getting_started' %} class="active"{% endif %}>
+          <!-- <li {%- if pagename == 'getting_started' %} class="active"{% endif %}>
             <a href="{{ pathto('getting_started') }}">Getting started</a>
-          </li>
+          </li> -->
 
           <li {%- if pagename == 'tutorials' %} class="active"{% endif %}>
-            <a href="{{ pathto('tutorials') }}">Tutorials</a>
+            <a href="{{ pathto('tutorials/index') }}">Tutorials</a>
           </li>
 
           <li>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Resolving #76 and #77 by removing the getting started link as there is no separate documentation there, and fixing the tutorials link on the header.


### Details and comments

Minimal changes, simply removing one link from header and fixing the tutorial link, which now points to the `index.html` file the `tutorials` folder.
