### PR TITLE
Add warning filter to qutip import in qutip compatibility tests

### DIFF
--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -15,6 +15,7 @@
 Shared functionality and helpers for the unit tests.
 """
 
+import warnings
 import unittest
 from typing import Callable, Iterable
 import numpy as np
@@ -110,7 +111,9 @@ class TestQutipBase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         try:
-            # pylint: disable=import-outside-toplevel,unused-import
-            import qutip
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                # pylint: disable=import-outside-toplevel,unused-import
+                import qutip
         except Exception as err:
             raise unittest.SkipTest("Skipping qutip tests.") from err


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When running tests locally (and I assume in the CI as well) warnings are raised when importing qutip (e.g. the current iteration is a scipy deprecation warning). Given that these tests are only to validate the ability to detect and convert qutip `Qobj` to our internal formats, there is no benefit to seeing these warnings.

### Details and comments


