### PR TITLE
change required black version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 stestr>=3.0.0
 astroid==2.9.3
 pylint==2.12.2
-black==22.1.0
+black~=22.0
 qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints
 jupyter-sphinx


### PR DESCRIPTION
### Summary
Solves https://github.com/psf/black/issues/2964, which was causing issues with the CI. Solution is to modify `requirements-dev.txt` so that the newer black version can be used.

### Details and comments


