### PR TITLE
Add explicit deprecation of carriers argument as list in InstructionToSignals

### DIFF
--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -14,6 +14,7 @@
 Pulse schedule to Signals converter.
 """
 
+import warnings
 from typing import Dict, List, Optional
 import numpy as np
 
@@ -78,6 +79,15 @@ class InstructionToSignals:
 
         self._dt = dt
         self._channels = channels
+
+        if isinstance(carriers, list):
+            warnings.warn(
+                "Passing `carriers` as a list has been deprecated and will be removed"
+                "as of next release. Pass `carriers` as a dict explicitly mapping "
+                "channel names to frequency values instead.",
+                DeprecationWarning,
+            )
+
         self._carriers = carriers or {}
 
     def get_signals(self, schedule: Schedule) -> List[DiscreteSignal]:
@@ -99,11 +109,19 @@ class InstructionToSignals:
         for idx, chan in enumerate(schedule.channels):
             phases[chan.name] = 0.0
             frequency_shifts[chan.name] = 0.0
+
+            # handle deprecated list case
+            carrier_freq = None
+            if isinstance(self._carriers, list):
+                carrier_freq = self._carriers[idx]
+            else:
+                carrier_freq = self._carriers.get(chan.name, 0.0)
+
             signals[chan.name] = DiscreteSignal(
                 samples=[],
                 dt=self._dt,
                 name=chan.name,
-                carrier_freq=self._carriers.get(chan.name, 0.0),
+                carrier_freq=carrier_freq,
             )
 
         for start_sample, inst in schedule.instructions:

--- a/releasenotes/notes/pulse-converter-filtering-8c919fa5b330a709.yaml
+++ b/releasenotes/notes/pulse-converter-filtering-8c919fa5b330a709.yaml
@@ -7,3 +7,9 @@ upgrade:
     as "d0", in the same order in which they are given. Furthermore, the
     ``carriers`` argument is updated to a dictionary to make the mapping from
     channel names to carrier frequencies more obvious.
+deprecations:
+  - |
+    Passing the ``carriers`` argument to ``InstructionToSignals`` as a ``list``
+    has been deprecated and will be removed next release. The ``carriers`` argument
+    should now be passed as a dictionary with channel names as keys and carrier
+    frequencies as values.

--- a/test/dynamics/signals/test_pulse_to_signals.py
+++ b/test/dynamics/signals/test_pulse_to_signals.py
@@ -44,6 +44,21 @@ from ..common import QiskitDynamicsTestCase
 class TestPulseToSignals(QiskitDynamicsTestCase):
     """Tests the conversion between pulse schedules and signals."""
 
+    def test_deprecated_carriers(self):
+        """Test that carriers as a list still works and raises deprecation warning."""
+
+        sched = Schedule(name="Schedule")
+        sched += Play(Gaussian(duration=20, amp=0.5, sigma=4), DriveChannel(0))
+
+        with self.assertWarns(DeprecationWarning):
+            converter = InstructionToSignals(dt=0.222, carriers=[5.5e9])
+
+        signals = converter.get_signals(sched)
+
+        self.assertEqual(signals[0].carrier_freq, 5.5e9)
+        # pylint: disable=protected-access
+        self.assertEqual(signals[0]._dt, 0.222)
+
     def test_pulse_to_signals(self):
         """Generic test."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #88.

### Details and comments

Re-adds the handling of ``carriers`` being passed as a list to the ``InstructionToSignals`` constructor. If passed as a list, a ``DeprecationWarning`` is raised indicating that this will be removed in the subsequent release. A new test has also been added to verify this behaviour.
