### PR TITLE
Adding state shape preservation to Solver.solve

### DIFF
--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -18,7 +18,7 @@ Solver classes.
 """
 
 
-from typing import Optional, Union, Tuple, Any, Type, List
+from typing import Optional, Union, Tuple, Any, Type, List, Callable
 from copy import copy
 
 import numpy as np
@@ -250,7 +250,7 @@ class Solver:
         if isinstance(y0, QuantumState) and isinstance(self.model, LindbladModel):
             y0 = DensityMatrix(y0)
 
-        y0, y0_cls = initial_state_converter(y0, return_class=True)
+        y0, y0_cls, state_type_wrapper = initial_state_converter(y0)
 
         # validate types
         if (y0_cls is SuperOp) and is_lindblad_model_not_vectorized(self.model):
@@ -312,56 +312,39 @@ class Solver:
             results.y = Array(results.y).reshape((len(results.y),) + y_input.shape, order="F")
 
         if y0_cls is not None:
-            results.y = [final_state_converter(yi, y0_cls) for yi in results.y]
+            results.y = [state_type_wrapper(yi) for yi in results.y]
 
         return results
 
 
-def initial_state_converter(
-    obj: Any, return_class: bool = False
-) -> Union[Array, Tuple[Array, Type]]:
-    """Convert initial state object to an Array.
+def initial_state_converter(obj: Any) -> Tuple[Array, Type, Callable]:
+    """Convert initial state object to an Array, the type of the initial input, and return
+    function for constructing a state of the same type.
 
     Args:
         obj: An initial state.
-        return_class: Optional. If True return the class to use
-                      for converting the output y Array.
 
     Returns:
-        Array: the converted initial state if ``return_class=False``.
-        tuple: (Array, class) if ``return_class=True``.
+        tuple: (Array, Type, Callable)
     """
     # pylint: disable=invalid-name
     y0_cls = None
     if isinstance(obj, Array):
-        y0, y0_cls = obj, None
+        y0, y0_cls, wrapper = obj, None, lambda x: x
     if isinstance(obj, QuantumState):
         y0, y0_cls = Array(obj.data), obj.__class__
+        wrapper = lambda x: y0_cls(np.array(x), dims=obj.dims())
     elif isinstance(obj, QuantumChannel):
         y0, y0_cls = Array(SuperOp(obj).data), SuperOp
+        wrapper = lambda x: SuperOp(
+            np.array(x), input_dims=obj.input_dims(), output_dims=obj.output_dims()
+        )
     elif isinstance(obj, (BaseOperator, Gate, QuantumCircuit)):
         y0, y0_cls = Array(Operator(obj.data)), Operator
+        wrapper = lambda x: Operator(
+            np.array(x), input_dims=obj.input_dims(), output_dims=obj.output_dims()
+        )
     else:
-        y0, y0_cls = Array(obj), None
-    if return_class:
-        return y0, y0_cls
-    return y0
+        y0, y0_cls, wrapper = Array(obj), None, lambda x: x
 
-
-def final_state_converter(obj: Any, cls: Optional[Type] = None) -> Any:
-    """Convert final state Array to custom class. If ``cls`` is not ``None``,
-    will explicitly convert ``obj`` into a ``numpy.array`` before wrapping,
-    under the assumption that ``cls`` will be a ``qiskit.quantum_info`` type,
-    which only support ``numpy.array``s.
-
-    Args:
-        obj: final state Array.
-        cls: Optional. The class to convert to.
-
-    Returns:
-        Any: the final state.
-    """
-    if cls is None:
-        return obj
-
-    return cls(np.array(obj))
+    return y0, y0_cls, wrapper

--- a/releasenotes/notes/solver-state-types-b5715520753ce510.yaml
+++ b/releasenotes/notes/solver-state-types-b5715520753ce510.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The ``Solver.solve`` method has been updated to preserve dimensionality data of the input
+    states when producing output states. E.g. if ``y0`` is a ``Statevector``, the output
+    states ``yf`` will satisfy ``yf.dims() == y0.dims()``.

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -191,6 +191,40 @@ class TestSolver(QiskitDynamicsTestCase):
         )
         self.method = "DOP853"
 
+    def test_state_dims_preservation(self):
+        """Test that state shapes are correctly preserved."""
+
+        # Hamiltonian only model
+        solver = Solver(static_hamiltonian=np.zeros((6, 6)))
+        y0 = Statevector(np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]), dims=(2, 3))
+        yf = solver.solve(t_span=[0.0, 0.1], y0=y0).y[-1]
+        self.assertTrue(isinstance(yf, Statevector))
+        self.assertTrue(yf.dims() == (2, 3))
+
+        y0 = DensityMatrix(np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]), dims=(2, 3))
+        yf = solver.solve(t_span=[0.0, 0.1], y0=y0).y[-1]
+        self.assertTrue(isinstance(yf, DensityMatrix))
+        self.assertTrue(yf.dims() == (2, 3))
+
+        # model with Lindblad terms
+        solver = Solver(static_dissipators=np.zeros((1, 6, 6)))
+        y0 = Statevector(np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]), dims=(2, 3))
+        yf = solver.solve(t_span=[0.0, 0.1], y0=y0).y[-1]
+        self.assertTrue(isinstance(yf, DensityMatrix))
+        self.assertTrue(yf.dims() == (2, 3))
+
+        y0 = DensityMatrix(np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]), dims=(2, 3))
+        yf = solver.solve(t_span=[0.0, 0.1], y0=y0).y[-1]
+        self.assertTrue(isinstance(yf, DensityMatrix))
+        self.assertTrue(yf.dims() == (2, 3))
+
+        # SuperOp
+        solver.model.evaluation_mode = "dense_vectorized"
+        y0 = SuperOp(np.eye(6**2), input_dims=(2, 3), output_dims=(3, 2))
+        yf = solver.solve(t_span=[0.0, 0.1], y0=y0).y[-1]
+        self.assertTrue(isinstance(yf, SuperOp))
+        self.assertTrue(yf.input_dims() == (2, 3) and yf.output_dims() == (3, 2))
+
     def test_lindblad_solve_statevector(self):
         """Test correct conversion of Statevector to DensityMatrix."""
 

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -220,7 +220,7 @@ class TestSolver(QiskitDynamicsTestCase):
 
         # SuperOp
         solver.model.evaluation_mode = "dense_vectorized"
-        y0 = SuperOp(np.eye(6**2), input_dims=(2, 3), output_dims=(3, 2))
+        y0 = SuperOp(np.eye(36), input_dims=(2, 3), output_dims=(3, 2))
         yf = solver.solve(t_span=[0.0, 0.1], y0=y0).y[-1]
         self.assertTrue(isinstance(yf, SuperOp))
         self.assertTrue(yf.input_dims() == (2, 3) and yf.output_dims() == (3, 2))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #96
Resolves the issue raised in discussion #95

`Solver.solve` respects input state type in the sense that if `y0` is a quantum info type, then the returned solution is wrapped in the same class. However, as pointed out in discussion #95, the dimension data of `y0` was not preserved when wrapping the solutions. This PR ensures updates `Solver.solve` to fix this. 

### Details and comments

The state type handling in `Solver.solve` is handled by `initial_state_converter` and `final_state_converter`. This PR updates `initial_state_converter` to also return a `wrapper` function to call to wrap the final states. This `wrapper` function is setup to include any additional kwargs needed beyond the array at construction - in this case dimension data. The function `final_state_converter` is removed as it is now redundant.

A test is also added to verify correct behaviour for various input types.