### PR TITLE
Lindblad model RWA bug fix

### DIFF
--- a/qiskit_dynamics/models/rotating_wave_approximation.py
+++ b/qiskit_dynamics/models/rotating_wave_approximation.py
@@ -232,7 +232,7 @@ def rotating_wave_approximation(
         )
 
         if return_signal_map:
-            signal_translator = lambda a, b: (get_rwa_signals(a), get_rwa_signals(b))
+            signal_translator = lambda a: (get_rwa_signals(a[0]), get_rwa_signals(a[1]))
             return rwa_model, signal_translator
         return rwa_model
 

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -190,7 +190,9 @@ class Solver:
         return self._signals
 
     @signals.setter
-    def signals(self, new_signals: Union[List[Signal], SignalList]):
+    def signals(
+        self, new_signals: Union[List[Signal], SignalList, Tuple[List[Signal]], Tuple[SignalList]]
+    ):
         """Set signals for the solver, and pass to the model."""
         self._signals = new_signals
         if self._rwa_signal_map is not None:

--- a/releasenotes/notes/lindblad-rwa-bug-491aaeed27ab4780.yaml
+++ b/releasenotes/notes/lindblad-rwa-bug-491aaeed27ab4780.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The ``rotating_wave_approximation`` function has been fixed in the case of
+    the ``model`` argument being a ``LindbladModel`` with ``return_signal_map=True``.
+    The returned signal mapping function was erroneously defined to take two inputs,
+    one for Hamiltonian signals and one for dissipator signals. This behaviour has been updated
+    to be consistent with the documentation, which states that in general this function accepts
+    only a single argument (in this case a tuple storing both sets of signals).

--- a/test/dynamics/models/test_rotating_wave_approximation.py
+++ b/test/dynamics/models/test_rotating_wave_approximation.py
@@ -282,13 +282,13 @@ class TestRotatingWaveApproximation(QiskitDynamicsTestCase):
             dissipator_signals=sigs,
         )
         f = rotating_wave_approximation(LM, 100, return_signal_map=True)[1]
-        rwa_ham_sig, rwa_dis_sig = f(sigs, sigs)
+        rwa_ham_sig, rwa_dis_sig = f((sigs, sigs))
         self.assertAllClose(rwa_ham_sig.complex_value(2)[:4], SignalList(sigs).complex_value(2))
         self.assertAllClose(rwa_dis_sig.complex_value(2)[:4], SignalList(sigs).complex_value(2))
         self.assertAllClose(rwa_ham_sig.complex_value(2)[4:], SignalList(s_prime).complex_value(2))
         self.assertAllClose(rwa_dis_sig.complex_value(2)[4:], SignalList(s_prime).complex_value(2))
 
-        self.assertTrue(f(None, None) == (None, None))
+        self.assertTrue(f((None, None)) == (None, None))
 
     def test_rwa_operators(self):
         """Tests get_rwa_operators using pseudorandom numbers."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bug in the `rotating_wave_approximation` function for when `model` is a `LindbladModel` and `return_signal_map=True`. The signature of the returned signal mapping function was inconsistent with the documentation, and has been fixed to restore consistency.

### Details and comments

For a `LindbladModel` the rwa signal mapping function must act on both the Hamiltonian signals as well as the dissipator signals. The documentation for the `rotating_wave_approximation` implies that the returned signal mapping function, in the case of a `LindbladModel`, should have a single argument, corresponding to the structure of the `LindbladModel.signals` property, which contains both the Hamiltonian and dissipator signals in a two-entry tuple.

Currently, however, the signal mapping  function returned by `rotating_wave_approximation` accepts the Hamiltonian and dissipator signals as two separate arguments, which is inconsistent. This PR fixes this to be consistent with the documentation.