### PR TITLE
Fixing single-line pylint disable of unused-import

### DIFF
--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -23,8 +23,7 @@ from copy import copy
 
 import numpy as np
 
-# pylint: disable=unused-import
-from scipy.integrate._ivp.ivp import OdeResult
+from scipy.integrate._ivp.ivp import OdeResult  # pylint: disable=unused-import
 
 from qiskit import QiskitError
 
@@ -32,10 +31,9 @@ from qiskit.circuit import Gate, QuantumCircuit
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
 from qiskit.quantum_info.states.quantum_state import QuantumState
-from qiskit.quantum_info import SuperOp, Operator, Statevector, DensityMatrix
+from qiskit.quantum_info import SuperOp, Operator, DensityMatrix
 
 from qiskit_dynamics.models import (
-    BaseGeneratorModel,
     HamiltonianModel,
     LindbladModel,
     RotatingFrame,

--- a/qiskit_dynamics/solvers/solver_functions.py
+++ b/qiskit_dynamics/solvers/solver_functions.py
@@ -21,25 +21,14 @@ from typing import Optional, Union, Callable, Tuple, List
 
 from scipy.integrate import OdeSolver
 
-# pylint: disable=unused-import
-from scipy.integrate._ivp.ivp import OdeResult
-
-from qiskit.circuit import Gate, QuantumCircuit
-from qiskit.quantum_info.operators.base_operator import BaseOperator
-from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
-from qiskit.quantum_info.states.quantum_state import QuantumState
-from qiskit.quantum_info import SuperOp, Operator
+from scipy.integrate._ivp.ivp import OdeResult  # pylint: disable=unused-import
 
 from qiskit import QiskitError
-from qiskit_dynamics.dispatch import requires_backend
 from qiskit_dynamics.array import Array
 
 from qiskit_dynamics.models import (
     BaseGeneratorModel,
     GeneratorModel,
-    RotatingFrame,
-    rotating_wave_approximation,
-    HamiltonianModel,
     LindbladModel,
 )
 
@@ -54,12 +43,6 @@ from .fixed_step_solvers import (
 )
 from .scipy_solve_ivp import scipy_solve_ivp, SOLVE_IVP_METHODS
 from .jax_odeint import jax_odeint
-
-try:
-    from jax.lax import scan
-except ImportError:
-    pass
-
 
 ODE_METHODS = (
     ["RK45", "RK23", "BDF", "DOP853", "Radau", "LSODA"]  # scipy solvers

--- a/test/dynamics/common.py
+++ b/test/dynamics/common.py
@@ -109,7 +109,6 @@ class TestQutipBase(unittest.TestCase):
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                # pylint: disable=import-outside-toplevel,unused-import
-                import qutip
+                import qutip  # pylint: disable=import-outside-toplevel,unused-import
         except Exception as err:
             raise unittest.SkipTest("Skipping qutip tests.") from err


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Both `solvers/solver_functions` and `solver/solver_classes` had the lines:

```
# pylint: disable=unused-import
from scipy.integrate._ivp.ivp import OdeResult
```

`OdeResult` is being imported for type-hinting, but since it isn't being used for anything else the pylint error `unused-import` was being raised.

The intention was to disable this error for only the `OdeResult` import, but it actually accidentally disables it for the entire file, rather than just the single line. This has been corrected and the unused imports in these files have been removed.