### PR TITLE
Refactor helper function for setting up list simulation

### DIFF
--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -45,7 +45,11 @@ from qiskit_dynamics.array import Array
 from qiskit_dynamics.dispatch.dispatch import Dispatch
 
 from .solver_functions import solve_lmde
-from .solver_utils import is_lindblad_model_vectorized, is_lindblad_model_not_vectorized, setup_arg_lists
+from .solver_utils import (
+    is_lindblad_model_vectorized,
+    is_lindblad_model_not_vectorized,
+    setup_args_lists,
+)
 
 
 class Solver:
@@ -599,10 +603,10 @@ def setup_simulation_lists(
 
         return t_span, was_list
 
-    return setup_arg_lists(
-        input_list=[t_span_input, y0_input, signals_input],
-        input_names=['t_span', 'y0', 'signals'],
-        input_to_list=[t_span_to_list, y0_to_list, signals_to_list]
+    return setup_args_lists(
+        args_list=[t_span_input, y0_input, signals_input],
+        args_names=["t_span", "y0", "signals"],
+        args_to_list=[t_span_to_list, y0_to_list, signals_to_list],
     )
 
 

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -129,63 +129,64 @@ def trim_t_results(
 
     return results
 
-def setup_arg_lists(
-    input_list: List[any],
-    input_names: List[str],
-    input_to_list: List[Callable]
-) -> Tuple[List[List[any]], bool]:
-    """Transform each entry of ``input_list`` into lists of the same length.
 
-    All elements of arg_inputs must be either given as lists of valid specifications,
-    or as a singleton of a valid specification. Whether or not an argument is a
-    'valid specification' is determined by the callables in ``is_single_instance_list``,
-    which must return boolean values. Singletons are transformed into a list of length one,
-    then all arguments are expanded to be the same length as the longest argument max_len:
-    For input in input_list:
-        - If len(input) == 1, it will be repeated max_len times
-        - if len(input) == max_len, nothing is done
-        - If len(input) not in (1, max_len), an error is raised
+def setup_args_lists(
+    args_list: List[any], args_names: List[str], args_to_list: List[Callable]
+) -> Tuple[List[List[any]], bool]:
+    """Transform each entry of ``args_list`` into lists of the same length.
+
+    All elements of args_list must be either given as lists of valid specifications,
+    or as a singleton of a valid specification. ``args_to_list`` contains a list of functions
+    that maps its corresponding entry in args_list to a valid list of singletons, along
+    with a bool indicating whether the corresponding argument was already a list of singletons.
+    All args are expanded to be the same length as the longest argument. For input in args_list:
+        - If len(arg) == 1, it will be repeated max_len times
+        - if len(arg) == max_len, nothing is done
+        - If len(arg) not in (1, max_len), an error is raised
 
     Args:
-        input_list: List of 'inputs'.
-        input_names: Names of inputs, used for error raising.
-        input_to_list: A list of functions that, when evaluated on the corresponding entry of
-                       input_list, returns a version of input_list converted to a list, along
-                       with a boolean stating whether the input was a single instance or
-                       was specified as a list. Specialized error handling for the entries in
-                       input_list should be part of these functions.
+        args_list: List of 'inputs'.
+        args_names: Names of inputs, used for error raising.
+        args_to_list: As described in the main function doc. Specialized error handling for
+                      the entries in args_list should be part of these functions in the
+                      case that the arg is neither a valid singleton, nor a valid list
+                      of singletons.
 
     Returns:
-        Tuple: First entry is the transformed version of input_list so that all entries are the
+        Tuple: First entry is the transformed version of args_list so that all entries are the
                lists of the same length. Second entry is a boolean stating whether the inputs
                were given all as single instances (False), or one was a list (True).
+
+    Raises:
+        QiskitError: If inputs have incompatible lengths.
     """
 
-    inputs_as_lists = []
-    inputs_were_lists = False
-    for input, to_list in zip(input_list, input_to_list):
-        input_as_list, input_was_list = to_list(input)
-        inputs_as_lists.append(input_as_list)
-        inputs_were_lists = inputs_were_lists or input_was_list
+    args_as_lists = []
+    args_were_lists = False
+    for arg, to_list in zip(args_list, args_to_list):
+        arg_as_list, arg_was_list = to_list(arg)
+        args_as_lists.append(arg_as_list)
+        args_were_lists = args_were_lists or arg_was_list
 
-    input_lens = [len(x) for x in inputs_as_lists]
-    max_len = max(input_lens)
-    for idx, input_len in enumerate(input_lens):
-        if input_len not in (1, max_len):
-            max_name = input_names[input_lens.index(max_len)]
+    arg_lens = [len(x) for x in args_as_lists]
+    max_len = max(arg_lens)
+    for idx, arg_len in enumerate(arg_lens):
+        if arg_len not in (1, max_len):
+            max_name = args_names[arg_lens.index(max_len)]
 
-            input_name_sequence = ''
-            for name in input_names[:-1]:
-                input_name_sequence += f'{name}, '
-            input_name_sequence += f'and {input_names[-1]}'
+            arg_name_sequence = ""
+            for name in args_names[:-1]:
+                arg_name_sequence += f"{name}, "
+            arg_name_sequence += f"and {args_names[-1]}"
 
-            bad_input = input_names[idx]
             raise QiskitError(
-                f"""If one of {input_name_sequence} is given as a list of valid inputs, then the
+                f"""If one of {arg_name_sequence} is given as a list of valid inputs, then the
                 others must specify only a single input, or a list of the same length.
-                {max_name} specifies {max_len} inputs, but {bad_input} is of length {input_len},
+                {max_name} specifies {max_len} inputs, but {args_names[idx]} is of length {arg_len},
                 which is incompatible."""
             )
 
-    inputs_as_lists = [x * max_len if input_len == 1 else x for x, input_len in zip(inputs_as_lists, input_lens)]
-    return inputs_as_lists, inputs_were_lists
+    args_as_lists = [
+        x * max_len if arg_len == 1 else x for x, arg_len in zip(args_as_lists, arg_lens)
+    ]
+    return args_as_lists, args_were_lists

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -17,9 +17,11 @@
 Utility functions for solvers.
 """
 
-from typing import Optional, Union, List, Tuple
+from typing import Optional, Union, List, Tuple, Callable
 import numpy as np
 from scipy.integrate._ivp.ivp import OdeResult
+
+from qiskit import QiskitError
 
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.models import LindbladModel
@@ -126,3 +128,64 @@ def trim_t_results(
         results.y = Array(results.y[:-1])
 
     return results
+
+def setup_arg_lists(
+    input_list: List[any],
+    input_names: List[str],
+    input_to_list: List[Callable]
+) -> Tuple[List[List[any]], bool]:
+    """Transform each entry of ``input_list`` into lists of the same length.
+
+    All elements of arg_inputs must be either given as lists of valid specifications,
+    or as a singleton of a valid specification. Whether or not an argument is a
+    'valid specification' is determined by the callables in ``is_single_instance_list``,
+    which must return boolean values. Singletons are transformed into a list of length one,
+    then all arguments are expanded to be the same length as the longest argument max_len:
+    For input in input_list:
+        - If len(input) == 1, it will be repeated max_len times
+        - if len(input) == max_len, nothing is done
+        - If len(input) not in (1, max_len), an error is raised
+
+    Args:
+        input_list: List of 'inputs'.
+        input_names: Names of inputs, used for error raising.
+        input_to_list: A list of functions that, when evaluated on the corresponding entry of
+                       input_list, returns a version of input_list converted to a list, along
+                       with a boolean stating whether the input was a single instance or
+                       was specified as a list. Specialized error handling for the entries in
+                       input_list should be part of these functions.
+
+    Returns:
+        Tuple: First entry is the transformed version of input_list so that all entries are the
+               lists of the same length. Second entry is a boolean stating whether the inputs
+               were given all as single instances (False), or one was a list (True).
+    """
+
+    inputs_as_lists = []
+    inputs_were_lists = False
+    for input, to_list in zip(input_list, input_to_list):
+        input_as_list, input_was_list = to_list(input)
+        inputs_as_lists.append(input_as_list)
+        inputs_were_lists = inputs_were_lists or input_was_list
+
+    input_lens = [len(x) for x in inputs_as_lists]
+    max_len = max(input_lens)
+    for idx, input_len in enumerate(input_lens):
+        if input_len not in (1, max_len):
+            max_name = input_names[input_lens.index(max_len)]
+
+            input_name_sequence = ''
+            for name in input_names[:-1]:
+                input_name_sequence += f'{name}, '
+            input_name_sequence += f'and {input_names[-1]}'
+
+            bad_input = input_names[idx]
+            raise QiskitError(
+                f"""If one of {input_name_sequence} is given as a list of valid inputs, then the
+                others must specify only a single input, or a list of the same length.
+                {max_name} specifies {max_len} inputs, but {bad_input} is of length {input_len},
+                which is incompatible."""
+            )
+
+    inputs_as_lists = [x * max_len if input_len == 1 else x for x, input_len in zip(inputs_as_lists, input_lens)]
+    return inputs_as_lists, inputs_were_lists


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Refactors some of the logic of the internal function ``setup_simulation_lists`` in ``solver_classes.py`` into a function ``setup_args_lists`` in ``solver_utils.py``, so that it can be reused elsewhere (e.g. it is needed in #73 for setting up list simulation in the new solvers introduced there).

### Details and comments

``setup_simulation_lists`` supports the functionality for allowing a user to pass one or more of ``t_span``, ``y0``, and ``signals`` as lists to ``Solver.solve``, so that multiple simulations can be run with a single call. This consists of two parts:
- Checking whether each of those arguments are "single instances" or lists of single instances (e.g. is ``t_span`` specifying one interval, or a list of intervals?), and turning them all into lists regardless.
- Checking the compatibility of the argument lengths, then setting all to the same length (repeating single instances of necessary) 

The first part of the above is naturally tied to the specifics of the arguments ``t_span``, ``y0``, and ``signals``, however the second part is not, and this is what has been refactored into ``setup_args_lists`` to work for an arbitrary number of input arguments. This function takes in a list of arguments, a list of names of those arguments, and a list of functions for validating whether or not the argument is a "valid single input" or a list of "valid single inputs". It applies these functions to all of the arguments, and performs the second part above.

This allows the user to construct more functions like ``setup_simulation_lists`` by only needing to supply the list conversion/validation functions.