### PR TITLE
Changing all assertRaises to assertRaisesRegex in test cases

### DIFF
--- a/qiskit_dynamics/models/rotating_frame.py
+++ b/qiskit_dynamics/models/rotating_frame.py
@@ -660,7 +660,4 @@ def _is_herm_or_anti_herm(mat: Array, atol: Optional[float] = 1e-10, rtol: Optio
                 return mat
 
         # raise error if execution has made it this far
-        raise QiskitError(
-            """frame_operator must be either a Hermitian or
-                           anti-Hermitian matrix."""
-        )
+        raise QiskitError("""frame_operator must be either a Hermitian or anti-Hermitian matrix.""")

--- a/test/dynamics/models/test_generator_model.py
+++ b/test/dynamics/models/test_generator_model.py
@@ -36,48 +36,41 @@ class TestGeneratorModelErrors(QiskitDynamicsTestCase):
     def test_both_static_operator_operators_None(self):
         """Test errors raising for a mal-formed GeneratorModel."""
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "at least one of static_operator or operators"):
             GeneratorModel(static_operator=None, operators=None)
-        self.assertTrue("at least one of static_operator or operators" in str(qe.exception))
 
     def test_operators_None_signals_not_None(self):
         """Test setting signals with operators being None."""
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "Signals must be None if operators is None."):
             GeneratorModel(
                 static_operator=np.array([[1.0, 0.0], [0.0, -1.0]]), operators=None, signals=[1.0]
             )
-        self.assertTrue("Signals must be None if operators is None." in str(qe.exception))
 
         # test after initial instantiation
         model = GeneratorModel(static_operator=np.array([[1.0, 0.0], [0.0, -1.0]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "Signals must be None if operators is None."):
             model.signals = [1.0]
-        self.assertTrue("Signals must be None if operators is None." in str(qe.exception))
 
     def test_operators_signals_length_mismatch(self):
         """Test setting operators and signals to incompatible lengths."""
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "same length as operators."):
             GeneratorModel(operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]), signals=[1.0, 1.0])
-        self.assertTrue("same length as operators." in str(qe.exception))
 
         # test after initial instantiation
         model = GeneratorModel(operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "same length as operators."):
             model.signals = [1.0, 1.0]
-        self.assertTrue("same length as operators." in str(qe.exception))
 
     def test_signals_bad_format(self):
         """Test setting signals in an unacceptable format."""
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "unaccepted format."):
             GeneratorModel(operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]), signals=lambda t: t)
-        self.assertTrue("unaccepted format." in str(qe.exception))
 
         # test after initial instantiation
         model = GeneratorModel(operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "unaccepted format."):
             model.signals = lambda t: t
-        self.assertTrue("unaccepted format." in str(qe.exception))
 
 
 class TestGeneratorModel(QiskitDynamicsTestCase):

--- a/test/dynamics/models/test_hamiltonian_model.py
+++ b/test/dynamics/models/test_hamiltonian_model.py
@@ -34,30 +34,23 @@ class TestHamiltonianModelValidation(QiskitDynamicsTestCase):
     def test_operators_array_not_hermitian(self):
         """Test raising error if operators are not Hermitian."""
 
-        operators = [np.array([[0.0, 1.0], [0.0, 0.0]])]
-
-        with self.assertRaises(QiskitError) as qe:
-            HamiltonianModel(operators=operators)
-        self.assertTrue("operators must be Hermitian." in str(qe.exception))
+        with self.assertRaisesRegex(QiskitError, "operators must be Hermitian."):
+            HamiltonianModel(operators=[np.array([[0.0, 1.0], [0.0, 0.0]])])
 
     def test_operators_csr_not_hermitian(self):
         """Test raising error if operators are not Hermitian."""
 
-        operators = self.to_sparse([[[0.0, 1.0], [0.0, 0.0]]])
-
-        with self.assertRaises(QiskitError) as qe:
-            HamiltonianModel(operators=operators)
-        self.assertTrue("operators must be Hermitian." in str(qe.exception))
+        with self.assertRaisesRegex(QiskitError, "operators must be Hermitian."):
+            HamiltonianModel(operators=self.to_sparse([[[0.0, 1.0], [0.0, 0.0]]]))
 
     def test_static_operator_not_hermitian(self):
         """Test raising error if static_operator is not Hermitian."""
 
-        static_operator = np.array([[0.0, 1.0], [0.0, 0.0]])
-        operators = [np.array([[0.0, 1.0], [1.0, 0.0]])]
-
-        with self.assertRaises(QiskitError) as qe:
-            HamiltonianModel(operators=operators, static_operator=static_operator)
-        self.assertTrue("static_operator must be Hermitian." in str(qe.exception))
+        with self.assertRaisesRegex(QiskitError, "static_operator must be Hermitian."):
+            HamiltonianModel(
+                operators=[np.array([[0.0, 1.0], [1.0, 0.0]])],
+                static_operator=np.array([[0.0, 1.0], [0.0, 0.0]]),
+            )
 
     def test_validate_false(self):
         """Verify setting validate=False avoids error raising."""

--- a/test/dynamics/models/test_lindblad_model.py
+++ b/test/dynamics/models/test_lindblad_model.py
@@ -34,100 +34,87 @@ class TestLindbladModelErrors(QiskitDynamicsTestCase):
     def test_all_operators_None(self):
         """Test error raised if no operators set."""
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "requires at least one of"):
             LindbladModel()
-        self.assertTrue("requires at least one of" in str(qe.exception))
 
     def test_operators_None_signals_not_None(self):
         """Test setting signals with operators being None."""
 
         # test Hamiltonian signals
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "Hamiltonian signals must be None"):
             LindbladModel(
                 static_hamiltonian=np.array([[1.0, 0.0], [0.0, -1.0]]), hamiltonian_signals=[1.0]
             )
-        self.assertTrue("Hamiltonian signals must be None" in str(qe.exception))
 
         # test after initial instantiation
         model = LindbladModel(static_hamiltonian=np.array([[1.0, 0.0], [0.0, -1.0]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "Hamiltonian signals must be None"):
             model.signals = ([1.0], None)
-        self.assertTrue("Hamiltonian signals must be None" in str(qe.exception))
 
         # test dissipator signals
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "Dissipator signals must be None"):
             LindbladModel(
                 static_hamiltonian=np.array([[1.0, 0.0], [0.0, -1.0]]), dissipator_signals=[1.0]
             )
-        self.assertTrue("Dissipator signals must be None" in str(qe.exception))
 
         # test after initial instantiation
         model = LindbladModel(static_hamiltonian=np.array([[1.0, 0.0], [0.0, -1.0]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "Dissipator signals must be None"):
             model.signals = (None, [1.0])
-        self.assertTrue("Dissipator signals must be None" in str(qe.exception))
 
     def test_operators_signals_length_mismatch(self):
         """Test setting operators and signals to incompatible lengths."""
 
         # Test Hamiltonian signals
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "same length"):
             LindbladModel(
                 hamiltonian_operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]),
                 hamiltonian_signals=[1.0, 1.0],
             )
-        self.assertTrue("same length" in str(qe.exception))
 
         # test after initial instantiation
         model = LindbladModel(hamiltonian_operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "same length"):
             model.signals = ([1.0, 1.0], None)
-        self.assertTrue("same length" in str(qe.exception))
 
         # Test dissipator signals
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "same length"):
             LindbladModel(
                 dissipator_operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]),
                 dissipator_signals=[1.0, 1.0],
             )
-        self.assertTrue("same length" in str(qe.exception))
 
         # test after initial instantiation
         model = LindbladModel(dissipator_operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "same length"):
             model.signals = (None, [1.0, 1.0])
-        self.assertTrue("same length" in str(qe.exception))
 
     def test_signals_bad_format(self):
         """Test setting signals in an unacceptable format."""
 
         # test Hamiltonian signals
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "unaccepted format."):
             LindbladModel(
                 hamiltonian_operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]),
                 hamiltonian_signals=lambda t: t,
             )
-        self.assertTrue("unaccepted format." in str(qe.exception))
 
         # test after initial instantiation
         model = LindbladModel(hamiltonian_operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "unaccepted format."):
             model.signals = (lambda t: t, None)
-        self.assertTrue("unaccepted format." in str(qe.exception))
 
         # test dissipator signals
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "unaccepted format."):
             LindbladModel(
                 dissipator_operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]),
                 dissipator_signals=lambda t: t,
             )
-        self.assertTrue("unaccepted format." in str(qe.exception))
 
         # test after initial instantiation
         model = LindbladModel(dissipator_operators=np.array([[[1.0, 0.0], [0.0, -1.0]]]))
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "unaccepted format."):
             model.signals = (None, lambda t: t)
-        self.assertTrue("unaccepted format." in str(qe.exception))
 
 
 class TestLindbladModelValidation(QiskitDynamicsTestCase):
@@ -138,9 +125,8 @@ class TestLindbladModelValidation(QiskitDynamicsTestCase):
 
         hamiltonian_operators = [np.array([[0.0, 1.0], [0.0, 0.0]])]
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "hamiltonian_operators must be Hermitian."):
             LindbladModel(hamiltonian_operators=hamiltonian_operators)
-        self.assertTrue("hamiltonian_operators must be Hermitian." in str(qe.exception))
 
     def test_static_operator_not_hermitian(self):
         """Test raising error if static_hamiltonian is not Hermitian."""
@@ -148,11 +134,10 @@ class TestLindbladModelValidation(QiskitDynamicsTestCase):
         static_hamiltonian = np.array([[0.0, 1.0], [0.0, 0.0]])
         hamiltonian_operators = [np.array([[0.0, 1.0], [1.0, 0.0]])]
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "static_hamiltonian must be Hermitian."):
             LindbladModel(
                 hamiltonian_operators=hamiltonian_operators, static_hamiltonian=static_hamiltonian
             )
-        self.assertTrue("static_hamiltonian must be Hermitian." in str(qe.exception))
 
     def test_validate_false(self):
         """Verify setting validate=False avoids error raising."""

--- a/test/dynamics/models/test_operator_collections.py
+++ b/test/dynamics/models/test_operator_collections.py
@@ -58,9 +58,8 @@ class TestDenseOperatorCollection(QiskitDynamicsTestCase):
         """Verify that evaluating with no operators or static_operator raises an error."""
 
         collection = DenseOperatorCollection(operators=None, static_operator=None)
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "cannot be evaluated."):
             collection(None)
-        self.assertTrue("cannot be evaluated." in str(qe.exception))
 
     def test_known_values_basic_functionality(self):
         """Test DenseOperatorCollection evaluation against
@@ -133,13 +132,11 @@ class TestSparseOperatorCollection(QiskitDynamicsTestCase):
         """Verify that evaluating with no operators or static_operator raises an error."""
 
         collection = SparseOperatorCollection(operators=None, static_operator=None)
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "cannot be evaluated."):
             collection(None)
-        self.assertTrue("cannot be evaluated." in str(qe.exception))
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "cannot be evaluated."):
             collection(None, np.array([1.0, 0.0]))
-        self.assertTrue("cannot be evaluated." in str(qe.exception))
 
     def test_evaluate_simple_case(self):
         """Simple test case."""
@@ -229,9 +226,8 @@ class TestJAXSparseOperatorCollection(QiskitDynamicsTestCase, TestJaxBase):
         """Verify that evaluating with no operators or static_operator raises an error."""
 
         collection = JAXSparseOperatorCollection(operators=None, static_operator=None)
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "cannot be evaluated."):
             collection(None)
-        self.assertTrue("cannot be evaluated." in str(qe.exception))
 
     def test_known_values_basic_functionality(self):
         """Test JAXSparseOperatorCollection evaluation against
@@ -329,13 +325,11 @@ class TestDenseLindbladCollection(QiskitDynamicsTestCase):
     def test_empty_collection_error(self):
         """Test errors get raised for empty collection."""
         collection = self.construct_collection()
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "cannot evaluate rhs"):
             collection(None, None, np.array([[1.0, 0.0], [0.0, 0.0]]))
-        self.assertTrue("cannot evaluate rhs" in str(qe.exception))
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "cannot evaluate Hamiltonian"):
             collection.evaluate_hamiltonian(None)
-        self.assertTrue("cannot evaluate Hamiltonian" in str(qe.exception))
 
     def test_no_static_hamiltonian_no_dissipator(self):
         """Test evaluation with just hamiltonian operators."""
@@ -640,13 +634,11 @@ class TestDenseVectorizedLindbladCollection(QiskitDynamicsTestCase):
     def test_empty_collection_error(self):
         """Test errors get raised for empty collection."""
         collection = self.vectorized_class()
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, self.vectorized_class.__name__ + " with None"):
             collection(None, None, np.array([[1.0, 0.0], [0.0, 0.0]]))
-        self.assertTrue(self.vectorized_class.__name__ + " with None" in str(qe.exception))
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, self.vectorized_class.__name__ + " with None"):
             collection.evaluate_hamiltonian(None)
-        self.assertTrue(self.vectorized_class.__name__ + " with None" in str(qe.exception))
 
     def test_consistency_all_terms(self):
         """Check consistency with non-vectorized class when hamiltonian,

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -35,13 +35,13 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
     def test_instantiation_errors(self):
         """Check different modes of error raising for frame setting."""
 
-        with self.assertRaises(QiskitError):
+        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
             RotatingFrame(Array([1.0, 1j]))
 
-        with self.assertRaises(QiskitError):
+        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
             RotatingFrame(Array([[1.0, 0.0], [0.0, 1j]]))
 
-        with self.assertRaises(QiskitError):
+        with self.assertRaisesRegex(QiskitError, "Hermitian or anti-Hermitian"):
             RotatingFrame(self.Z + 1j * self.X)
 
     def test_state_out_of_frame_basis(self):

--- a/test/dynamics/signals/test_pulse_to_signals.py
+++ b/test/dynamics/signals/test_pulse_to_signals.py
@@ -291,5 +291,5 @@ class TestPulseToSignalsFiltering(QiskitDynamicsTestCase):
 
         converter = InstructionToSignals(dt=0.222)
 
-        with self.assertRaises(QiskitError):
+        with self.assertRaisesRegex(QiskitError, f"channel name {channel_name}"):
             converter._get_channel(channel_name)

--- a/test/dynamics/solvers/test_solver_functions_interface.py
+++ b/test/dynamics/solvers/test_solver_functions_interface.py
@@ -38,10 +38,8 @@ class Testsolve_ode_exceptions(QiskitDynamicsTestCase):
     def test_method_does_not_exist(self):
         """Test method does not exist exception."""
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "not supported"):
             solve_ode(lambda t, y: y, t_span=[0.0, 1.0], y0=np.array([1.0]), method="notamethod")
-
-        self.assertTrue("not supported" in str(qe.exception))
 
 
 class Testsolve_lmde_exceptions(QiskitDynamicsTestCase):
@@ -55,19 +53,16 @@ class Testsolve_lmde_exceptions(QiskitDynamicsTestCase):
     def test_lmde_method_non_vectorized_lindblad(self):
         """Test error raising if LMDE method is specified for non-vectorized Lindblad."""
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "vectorized evaluation"):
             solve_lmde(
                 self.lindblad_model, t_span=[0.0, 1.0], y0=np.diag([1.0, 0.0]), method="scipy_expm"
             )
-        self.assertTrue("vectorized evaluation" in str(qe.exception))
 
     def test_method_does_not_exist(self):
         """Test method does not exist exception."""
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "not supported"):
             solve_lmde(lambda t: t, t_span=[0.0, 1.0], y0=np.array([1.0]), method="notamethod")
-
-        self.assertTrue("not supported" in str(qe.exception))
 
     def test_jax_expm_sparse_mode(self):
         """Verify an error gets raised if the jax expm solver is attempted to be used
@@ -77,12 +72,10 @@ class Testsolve_lmde_exceptions(QiskitDynamicsTestCase):
             static_operator=np.array([[0.0, 1.0], [1.0, 0.0]]), evaluation_mode="sparse"
         )
 
-        with self.assertRaises(QiskitError) as qe:
+        with self.assertRaisesRegex(QiskitError, "jax_expm cannot be used"):
             solve_lmde(
                 model, t_span=[0.0, 1.0], y0=np.array([1.0, 1.0]), method="jax_expm", max_dt=0.1
             )
-
-        self.assertTrue("jax_expm cannot be used" in str(qe.exception))
 
 
 class TestLMDEGeneratorModelSetup(QiskitDynamicsTestCase):

--- a/test/dynamics/solvers/test_solver_utils.py
+++ b/test/dynamics/solvers/test_solver_utils.py
@@ -29,29 +29,29 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
 
     def test_merge_t_args_dim_error(self):
         """Test raising of ValueError for non-1d t_eval."""
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "t_eval must be 1 dimensional."):
             merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([[0.0]]))
 
     def test_merge_t_args_interval_error(self):
         """Test raising ValueError if t_eval not in t_span."""
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "t_eval entries must lie in t_span."):
             merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([1.5]))
 
     def test_merge_t_args_interval_error_backwards(self):
         """Test raising ValueError if t_eval not in t_span for backwards integration."""
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "t_eval entries must lie in t_span."):
             merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-1.5]))
 
     def test_merge_t_args_sort_error(self):
         """Test raising ValueError if t_eval is not correctly sorted."""
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "t_eval must be ordered"):
             merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.75, 0.25]))
 
     def test_merge_t_args_sort_error_backwards(self):
         """Test raising ValueError if t_eval is not correctly sorted for
         backwards integration.
         """
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "t_eval must be ordered"):
             merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-0.75, -0.25]))
 
     def test_merge_t_args_no_overlap(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changes all unittest calls to `assertRaises` to `assertRaisesRegex`, which allows for more concise validation that a particular error type is raises with a particular message.

### Details

There were many instances throughout the tests where `assertRaises` was used, and a followup line would check that the message contained a certain string. These were written before I knew about `assertRaisesRegex`. Minor, but cleaner, and is the way thing should be done going forward.
