### PR TITLE
Delaying diffrax import as late as possible

### DIFF
--- a/qiskit_dynamics/solvers/diffrax_solver.py
+++ b/qiskit_dynamics/solvers/diffrax_solver.py
@@ -26,14 +26,9 @@ from qiskit_dynamics.array import Array, wrap
 
 from .solver_utils import merge_t_args
 
-
 try:
-    from diffrax import ODETerm, SaveAt
-    from diffrax import diffeqsolve as _diffeqsolve
-
-    from diffrax.solver import AbstractSolver  # pylint: disable=unused-import
     import jax.numpy as jnp
-except ImportError as err:
+except ImportError:
     pass
 
 
@@ -63,6 +58,11 @@ def diffrax_solver(
         QiskitError: Passing both `SaveAt` argument and `t_eval` argument.
     """
 
+    from diffrax import ODETerm, SaveAt
+    from diffrax import diffeqsolve as _diffeqsolve
+
+    diffeqsolve = wrap(_diffeqsolve)
+
     t_list = merge_t_args(t_span, t_eval)
 
     # convert rhs and y0 to real
@@ -70,8 +70,6 @@ def diffrax_solver(
     y0 = c2r(y0)
 
     term = ODETerm(lambda t, y, _: Array(rhs(t.real, y), dtype=float).data)
-
-    diffeqsolve = wrap(_diffeqsolve)
 
     if "saveat" in kwargs and t_eval is not None:
         raise QiskitError(

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -47,7 +47,7 @@ from qiskit_dynamics.pulse import InstructionToSignals
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.dispatch.dispatch import Dispatch
 
-from .solver_functions import solve_lmde, is_jax_method
+from .solver_functions import solve_lmde, _is_jax_method
 from .solver_utils import (
     is_lindblad_model_vectorized,
     is_lindblad_model_not_vectorized,
@@ -597,7 +597,7 @@ class Solver:
         all_results = None
         if (
             Array.default_backend() == "jax"
-            and is_jax_method(kwargs.get("method", ""))
+            and _is_jax_method(kwargs.get("method", ""))
             and all(isinstance(x, Schedule) for x in signals_list)
         ):
             all_results = self._solve_schedule_list_jax(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently, diffrax is raising a JAX deprecation warning on import. To avoid raising this warning when a user imports Dynamics while diffrax is installed, this PR moves all `diffrax` imports and solver type-checks to be as late as possible, so that it is only imported once a user actually tries to call a diffrax solver (which requires the user to import diffrax themselves).

### Details and comments

Moved all diffrax imports into functions, and set type-checks for diffrax solvers to always be last when iterating through the possible solver types. Diffrax will therefore only be imported if:
- A user is actually trying to call a diffrax solver.
- A user passes an invalid `method` kwarg to one of the `Solver.solve`/`solve_lmde`/`solve_ode` methods, which will eventually raise an error anyway.

To preserve type hints for `solve_lmde` and `solve_ode`, a type variable `TypeVar('AbstractSolver')` is created to use in the function signatures.