### PR TITLE
Fix RotatingFrame basis transformation methods to work for a list of CSR matrices

### DIFF
--- a/releasenotes/notes/sparse-rotating-frame-bug-88fffd0f39d8128b.yaml
+++ b/releasenotes/notes/sparse-rotating-frame-bug-88fffd0f39d8128b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ``RotatingFrame.operator_into_frame_basis`` and ``RotatingFrame.operator_out_of_frame_basis``
+    was fixed to work on lists of scipy CSR matrices.

--- a/releasenotes/notes/sparse-rotating-frame-bug-88fffd0f39d8128b.yaml
+++ b/releasenotes/notes/sparse-rotating-frame-bug-88fffd0f39d8128b.yaml
@@ -2,4 +2,4 @@
 fixes:
   - |
     ``RotatingFrame.operator_into_frame_basis`` and ``RotatingFrame.operator_out_of_frame_basis``
-    was fixed to work on lists of scipy CSR matrices.
+    were fixed to work on lists of scipy CSR matrices.

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -97,6 +97,30 @@ class TestRotatingFrame(QiskitDynamicsTestCase):
         expected = U @ y0 @ Uadj
         self.assertAllClose(val, expected)
 
+    def test_operator_into_frame_basis_sparse_list(self):
+        """Test state_into_frame_basis for a list of sparse arrays."""
+
+        ops = [csr_matrix([[0.0, 1.0], [1.0, 0.0]]), csr_matrix([[1.0, 0.0], [0.0, -1.0]])]
+        rotating_frame = RotatingFrame(np.array([[0.0, 1.0], [1.0, 0.0]]))
+
+        val = rotating_frame.operator_into_frame_basis(ops)
+        U = rotating_frame.frame_basis
+        Uadj = rotating_frame.frame_basis_adjoint
+        expected = [U @ (op @ Uadj) for op in ops]
+        self.assertAllClose(val, expected)
+
+    def test_operator_out_of_frame_basis_sparse_list(self):
+        """Test state_out_of_frame_basis for a list of sparse arrays."""
+
+        ops = [csr_matrix([[0.0, 1.0], [1.0, 0.0]]), csr_matrix([[1.0, 0.0], [0.0, -1.0]])]
+        rotating_frame = RotatingFrame(np.array([[0.0, 1.0], [1.0, 0.0]]))
+
+        val = rotating_frame.operator_out_of_frame_basis(ops)
+        U = rotating_frame.frame_basis
+        Uadj = rotating_frame.frame_basis_adjoint
+        expected = [Uadj @ (op @ U) for op in ops]
+        self.assertAllClose(val, expected)
+
     def test_state_transformations_no_frame(self):
         """Test frame transformations with no frame."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The methods `RotatingFrame.operator_into_frame_basis` and `RotatingFrame.operator_out_of_frame_basis` are supposed to work on `Operator`, CSR matrices, lists of `Operator`, lists of CSR matrices, and JAX BCOO arrays. A bug was preventing them from working on a list of CSR matrices, which this PR fixes.

### Details and comments

Updates both functions so that, if a list of valid types are passed, the method will be recursively called on the elements of the list. To facilitate this, also added a `convert_type` optional argument to both that can be used to avoid the initial type conversion that takes places in these methods (which is unnecessary in the recursive calls).

Added tests for `RotatingFrame` to validate this behaviour on lists of CSR matrices.