### PR TITLE
Deprecation removals

### DIFF
--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -14,7 +14,6 @@
 Pulse schedule to Signals converter.
 """
 
-import warnings
 from typing import Dict, List, Optional
 import numpy as np
 
@@ -79,15 +78,6 @@ class InstructionToSignals:
 
         self._dt = dt
         self._channels = channels
-
-        if isinstance(carriers, list):
-            warnings.warn(
-                "Passing `carriers` as a list has been deprecated and will be removed"
-                "as of next release. Pass `carriers` as a dict explicitly mapping "
-                "channel names to frequency values instead.",
-                DeprecationWarning,
-            )
-
         self._carriers = carriers or {}
 
     def get_signals(self, schedule: Schedule) -> List[DiscreteSignal]:
@@ -110,12 +100,7 @@ class InstructionToSignals:
             phases[chan.name] = 0.0
             frequency_shifts[chan.name] = 0.0
 
-            # handle deprecated list case
-            carrier_freq = None
-            if isinstance(self._carriers, list):
-                carrier_freq = self._carriers[idx]
-            else:
-                carrier_freq = self._carriers.get(chan.name, 0.0)
+            carrier_freq = self._carriers.get(chan.name, 0.0)
 
             signals[chan.name] = DiscreteSignal(
                 samples=[],

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -19,8 +19,6 @@ Solver classes.
 
 
 from typing import Optional, Union, Tuple, Any, Type, List, Callable
-from copy import copy
-import warnings
 
 import numpy as np
 
@@ -384,18 +382,6 @@ class Solver:
     def model(self) -> Union[HamiltonianModel, LindbladModel]:
         """The model of the system, either a Hamiltonian or Lindblad model."""
         return self._model
-
-    def copy(self) -> "Solver":
-        """(Deprecated) Return a copy of self."""
-        warnings.warn(
-            """The copy method is deprecated and will be removed in the next release.
-            This deprecation is associated with the deprecation of the signals property;
-            the copy method will no longer be needed once the signal property is removed.""",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        return copy(self)
 
     def solve(
         self,

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -183,10 +183,8 @@ class Solver:
         self,
         static_hamiltonian: Optional[Array] = None,
         hamiltonian_operators: Optional[Array] = None,
-        hamiltonian_signals: Optional[Union[List[Signal], SignalList]] = None,
         static_dissipators: Optional[Array] = None,
         dissipator_operators: Optional[Array] = None,
-        dissipator_signals: Optional[Union[List[Signal], SignalList]] = None,
         hamiltonian_channels: Optional[List[str]] = None,
         dissipator_channels: Optional[List[str]] = None,
         channel_carrier_freqs: Optional[dict] = None,
@@ -205,15 +203,8 @@ class Solver:
                                 is specified, the ``frame_operator`` will be subtracted from
                                 the static_hamiltonian.
             hamiltonian_operators: Hamiltonian operators.
-            hamiltonian_signals: (Deprecated) Coefficients for the Hamiltonian operators.
-                                 This argument has been deprecated, signals should be passed
-                                 to the solve method.
             static_dissipators: Constant dissipation operators.
             dissipator_operators: Dissipation operators with time-dependent coefficients.
-            dissipator_signals: (Deprecated) Optional time-dependent coefficients for the
-                                dissipators. If ``None``, coefficients are assumed to be the
-                                constant ``1.``. This argument has been deprecated, signals
-                                should be passed to the solve method.
             hamiltonian_channels: List of channel names in pulse schedules corresponding to
                                   Hamiltonian operators.
             dissipator_channels: List of channel names in pulse schedules corresponding to
@@ -314,126 +305,85 @@ class Solver:
             else:
                 raise QiskitError("dt must be specified if channel information is provided.")
 
-        if hamiltonian_signals or dissipator_signals:
-            warnings.warn(
-                """hamiltonian_signals and dissipator_signals are deprecated arguments
-                and will be removed in a subsequent release.
-                Signals should be passed directly to the solve method.""",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         # setup model
         model = None
         if static_dissipators is None and dissipator_operators is None:
             model = HamiltonianModel(
                 static_operator=static_hamiltonian,
                 operators=hamiltonian_operators,
-                signals=hamiltonian_signals,
                 rotating_frame=rotating_frame,
                 in_frame_basis=in_frame_basis,
                 evaluation_mode=evaluation_mode,
                 validate=validate,
             )
-            self._signals = hamiltonian_signals
         else:
             model = LindbladModel(
                 static_hamiltonian=static_hamiltonian,
                 hamiltonian_operators=hamiltonian_operators,
-                hamiltonian_signals=hamiltonian_signals,
                 static_dissipators=static_dissipators,
                 dissipator_operators=dissipator_operators,
-                dissipator_signals=dissipator_signals,
                 rotating_frame=rotating_frame,
                 in_frame_basis=in_frame_basis,
                 evaluation_mode=evaluation_mode,
                 validate=validate,
             )
-            self._signals = (hamiltonian_signals, dissipator_signals)
 
         self._rwa_signal_map = None
+        self._model = model
         if rwa_cutoff_freq:
 
-            original_signals = model.signals
-            # if configured in pulse mode and rwa_carrier_freqs is None, use the channel
-            # carrier freqs
-            if rwa_carrier_freqs is None and self._channel_carrier_freqs is not None:
-                rwa_carrier_freqs = None
-                if self._hamiltonian_channels is not None:
-                    rwa_carrier_freqs = [
-                        self._channel_carrier_freqs[c] for c in self._hamiltonian_channels
+            # if rwa_carrier_freqs is None, take from channel_carrier_freqs or set all to 0.
+            if rwa_carrier_freqs is None:
+                if self._channel_carrier_freqs is not None:
+                    if self._hamiltonian_channels is not None:
+                        rwa_carrier_freqs = [
+                            self._channel_carrier_freqs[c] for c in self._hamiltonian_channels
+                        ]
+
+                    if self._dissipator_channels is not None:
+                        rwa_carrier_freqs = (
+                            rwa_carrier_freqs,
+                            [self._channel_carrier_freqs[c] for c in self._dissipator_channels],
+                        )
+                else:
+                    rwa_carrier_freqs = []
+                    if hamiltonian_operators is not None:
+                        rwa_carrier_freqs = [0.0] * len(hamiltonian_operators)
+
+                    if dissipator_operators is not None:
+                        rwa_carrier_freqs = (rwa_carrier_freqs, [0.0] * len(dissipator_operators))
+
+            if isinstance(rwa_carrier_freqs, tuple):
+                rwa_ham_sigs = None
+                rwa_lindblad_sigs = None
+                if rwa_carrier_freqs[0]:
+                    rwa_ham_sigs = [Signal(1.0, carrier_freq=freq) for freq in rwa_carrier_freqs[0]]
+                if rwa_carrier_freqs[1]:
+                    rwa_lindblad_sigs = [
+                        Signal(1.0, carrier_freq=freq) for freq in rwa_carrier_freqs[1]
                     ]
 
-                if self._dissipator_channels is not None:
-                    rwa_carrier_freqs = (
-                        rwa_carrier_freqs,
-                        [self._channel_carrier_freqs[c] for c in self._dissipator_channels],
-                    )
+                self._model.signals = (rwa_ham_sigs, rwa_lindblad_sigs)
+            else:
+                rwa_sigs = [Signal(1.0, carrier_freq=freq) for freq in rwa_carrier_freqs]
 
-            if rwa_carrier_freqs is not None:
-                if isinstance(rwa_carrier_freqs, tuple):
-                    rwa_ham_sigs = None
-                    rwa_lindblad_sigs = None
-                    if rwa_carrier_freqs[0]:
-                        rwa_ham_sigs = [
-                            Signal(1.0, carrier_freq=freq) for freq in rwa_carrier_freqs[0]
-                        ]
-                    if rwa_carrier_freqs[1]:
-                        rwa_lindblad_sigs = [
-                            Signal(1.0, carrier_freq=freq) for freq in rwa_carrier_freqs[1]
-                        ]
+                if isinstance(model, LindbladModel):
+                    rwa_sigs = (rwa_sigs, None)
 
-                    model.signals = (rwa_ham_sigs, rwa_lindblad_sigs)
-                else:
-                    rwa_sigs = [Signal(1.0, carrier_freq=freq) for freq in rwa_carrier_freqs]
+                self._model.signals = rwa_sigs
 
-                    if isinstance(model, LindbladModel):
-                        rwa_sigs = (rwa_sigs, None)
-
-                    model.signals = rwa_sigs
-
-            model, rwa_signal_map = rotating_wave_approximation(
-                model, rwa_cutoff_freq, return_signal_map=True
+            self._model, rwa_signal_map = rotating_wave_approximation(
+                self._model, rwa_cutoff_freq, return_signal_map=True
             )
             self._rwa_signal_map = rwa_signal_map
 
-            if hamiltonian_signals or dissipator_signals:
-                model.signals = self._rwa_signal_map(original_signals)
-
-        self._model = model
+            # clear signals
+            self._set_new_signals(None)
 
     @property
     def model(self) -> Union[HamiltonianModel, LindbladModel]:
         """The model of the system, either a Hamiltonian or Lindblad model."""
         return self._model
-
-    @property
-    def signals(self) -> SignalList:
-        """(Deprecated) The signals used in the solver."""
-        warnings.warn(
-            """The signals property is deprecated and will be removed in the next release.
-            Signals should be passed directly to the solve method.""",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self._signals
-
-    @signals.setter
-    def signals(
-        self, new_signals: Union[List[Signal], SignalList, Tuple[List[Signal]], Tuple[SignalList]]
-    ):
-        """(Deprecated) Set signals for the solver, and pass to the model."""
-        warnings.warn(
-            """The signals property is deprecated and will be removed in the next release.
-            Signals should be passed directly to the solve method.""",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-        self._signals = new_signals
-        if self._rwa_signal_map is not None:
-            new_signals = self._rwa_signal_map(new_signals)
-        self.model.signals = new_signals
 
     def copy(self) -> "Solver":
         """(Deprecated) Return a copy of self."""
@@ -567,19 +517,6 @@ class Solver:
 
             results = solver.solve(t_span=t_span, y0=y0, signals=signals)
         """
-        # hold copy of signals in model for deprecated behavior
-        original_signals = self.model.signals
-
-        # raise deprecation warning if signals is None and non-trivial signals to fall back on
-        if signals is None and not original_signals in (None, (None, None)):
-            warnings.warn(
-                """No signals specified to solve, falling back on signals stored in model.
-                Passing signals to Solver at instantiation and setting Solver.signals have been
-                deprecated and will be removed in the next release. Instead pass signals
-                directly to the solve method.""",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
         # convert any ScheduleBlocks to Schedules
         if isinstance(signals, ScheduleBlock):
@@ -615,6 +552,9 @@ class Solver:
                 convert_results=convert_results,
                 **kwargs,
             )
+
+        # ensure model signals are empty
+        self._set_new_signals(None)
 
         if multiple_sims is False:
             return all_results[0]
@@ -653,6 +593,8 @@ class Solver:
                 results.y = [state_type_wrapper(yi) for yi in results.y]
 
             all_results.append(results)
+
+        self._set_new_signals(None)
 
         return all_results
 
@@ -748,6 +690,11 @@ class Solver:
             if self._rwa_signal_map:
                 signals = self._rwa_signal_map(signals)
             self.model.signals = signals
+        else:
+            if isinstance(self.model, LindbladModel):
+                self.model.signals = (None, None)
+            else:
+                self.model.signals = None
 
     def _schedule_to_signals(self, schedule: Schedule):
         """Convert a schedule into the signal format required by the model."""

--- a/releasenotes/notes/deprecation-removals-3d445f09f3fa0044.yaml
+++ b/releasenotes/notes/deprecation-removals-3d445f09f3fa0044.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Passing the ``carriers`` argument to ``InstructionToSignals`` as a ``list`` is no longer
+    supported.

--- a/releasenotes/notes/deprecation-removals-3d445f09f3fa0044.yaml
+++ b/releasenotes/notes/deprecation-removals-3d445f09f3fa0044.yaml
@@ -3,6 +3,10 @@ upgrade:
   - |
     Passing the ``carriers`` argument to ``InstructionToSignals`` as a ``list`` is no longer
     supported.
-  - The ``Solver.signals`` property, and :class:`.Solver` init arguments ``hamiltonian_signals``
-    and ``dissipator_signals``, have been removed.
-  - The ``Solver.copy`` method has been removed.
+  - |
+    The :class:`.Solver` init arguments ``hamiltonian_signals`` and ``dissipator_signals`` have
+    been removed.
+  - |
+    The ``Solver.signals`` property has been removed.
+  - |
+    The ``Solver.copy`` method has been removed.

--- a/releasenotes/notes/deprecation-removals-3d445f09f3fa0044.yaml
+++ b/releasenotes/notes/deprecation-removals-3d445f09f3fa0044.yaml
@@ -3,3 +3,5 @@ upgrade:
   - |
     Passing the ``carriers`` argument to ``InstructionToSignals`` as a ``list`` is no longer
     supported.
+  - The ``Solver.signals`` property, and :class:`.Solver` init arguments ``hamiltonian_signals``
+    and ``dissipator_signals``, have been removed.

--- a/releasenotes/notes/deprecation-removals-3d445f09f3fa0044.yaml
+++ b/releasenotes/notes/deprecation-removals-3d445f09f3fa0044.yaml
@@ -5,3 +5,4 @@ upgrade:
     supported.
   - The ``Solver.signals`` property, and :class:`.Solver` init arguments ``hamiltonian_signals``
     and ``dissipator_signals``, have been removed.
+  - The ``Solver.copy`` method has been removed.

--- a/test/dynamics/signals/test_pulse_to_signals.py
+++ b/test/dynamics/signals/test_pulse_to_signals.py
@@ -44,21 +44,6 @@ from ..common import QiskitDynamicsTestCase
 class TestPulseToSignals(QiskitDynamicsTestCase):
     """Tests the conversion between pulse schedules and signals."""
 
-    def test_deprecated_carriers(self):
-        """Test that carriers as a list still works and raises deprecation warning."""
-
-        sched = Schedule(name="Schedule")
-        sched += Play(Gaussian(duration=20, amp=0.5, sigma=4), DriveChannel(0))
-
-        with self.assertWarns(DeprecationWarning):
-            converter = InstructionToSignals(dt=0.222, carriers=[5.5e9])
-
-        signals = converter.get_signals(sched)
-
-        self.assertEqual(signals[0].carrier_freq, 5.5e9)
-        # pylint: disable=protected-access
-        self.assertEqual(signals[0]._dt, 0.222)
-
     def test_pulse_to_signals(self):
         """Generic test."""
 

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -30,21 +30,6 @@ from qiskit_dynamics.solvers.solver_classes import organize_signals_to_channels
 from ..common import QiskitDynamicsTestCase, TestJaxBase
 
 
-class TestSolverDeprecations(QiskitDynamicsTestCase):
-    """Test deprecation warnings and deprecated behaviour."""
-
-    def setUp(self):
-        self.X = Operator.from_label("X")
-
-    def test_copy_deprecated(self):
-        """Test copy method raises deprecation warning."""
-
-        solver = Solver(hamiltonian_operators=[self.X])
-
-        with self.assertWarnsRegex(DeprecationWarning, "copy method is deprecated"):
-            solver.copy()
-
-
 class TestSolverValidation(QiskitDynamicsTestCase):
     """Test validation checks."""
 

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -16,7 +16,6 @@ Tests for solver classes module.
 """
 
 import numpy as np
-from scipy.linalg import expm
 from ddt import ddt, data, unpack
 
 from qiskit import pulse, QiskitError
@@ -37,26 +36,6 @@ class TestSolverDeprecations(QiskitDynamicsTestCase):
     def setUp(self):
         self.X = Operator.from_label("X")
 
-    def test_deprecated_signals_at_construction(self):
-        """Test deprecation warning raised when signals passed to constructor."""
-
-        with self.assertWarnsRegex(DeprecationWarning, "deprecated arguments"):
-            Solver(hamiltonian_operators=[self.X], hamiltonian_signals=[1.0])
-
-        with self.assertWarnsRegex(DeprecationWarning, "deprecated arguments"):
-            Solver(dissipator_operators=[self.X], dissipator_signals=[1.0])
-
-    def test_deprecated_signals_property(self):
-        """Test deprecation warning raised when setting or getting signals property."""
-
-        solver = Solver(hamiltonian_operators=[self.X])
-
-        with self.assertWarnsRegex(DeprecationWarning, "signals property is deprecated"):
-            solver.signals = [1.0]
-
-        with self.assertWarnsRegex(DeprecationWarning, "signals property is deprecated"):
-            solver.signals  # pylint: disable=pointless-statement
-
     def test_copy_deprecated(self):
         """Test copy method raises deprecation warning."""
 
@@ -64,45 +43,6 @@ class TestSolverDeprecations(QiskitDynamicsTestCase):
 
         with self.assertWarnsRegex(DeprecationWarning, "copy method is deprecated"):
             solver.copy()
-
-    def test_no_signals_to_solve(self):
-        """Test raising of deprecation warning if no signals passed to solve,
-        and signals present in model.
-        """
-
-        with self.assertWarnsRegex(DeprecationWarning, "deprecated arguments"):
-            solver = Solver(hamiltonian_operators=[self.X], hamiltonian_signals=[1.0])
-
-        with self.assertWarnsRegex(DeprecationWarning, "No signals specified to solve"):
-            solver.solve(t_span=[0.0, 0.1], y0=np.array([0.0, 1.0]))
-
-        with self.assertWarnsRegex(DeprecationWarning, "deprecated arguments"):
-            solver = Solver(
-                hamiltonian_operators=[self.X],
-                hamiltonian_signals=[1.0],
-                dissipator_operators=[self.X],
-                dissipator_signals=[1.0],
-            )
-
-        with self.assertWarnsRegex(DeprecationWarning, "No signals specified to solve"):
-            solver.solve(t_span=[0.0, 0.1], y0=np.array([[0.0, 0.0], [0.0, 1.0]]))
-
-    def test_replacing_signals_in_solve(self):
-        """Test that the signals stored in the signals attribute are correctly replaced."""
-
-        with self.assertWarnsRegex(DeprecationWarning, "deprecated arguments"):
-            solver = Solver(
-                hamiltonian_operators=[self.X],
-                hamiltonian_signals=[1.0],
-            )
-
-        y0 = np.array([1.0, 0.0])
-        results = solver.solve(t_span=[0.0, 0.1], y0=y0, signals=[2.0], atol=1e-10, rtol=1e-10)
-        expected = expm(-1j * 0.1 * 2 * self.X.data) @ y0
-        self.assertAllClose(results.y[-1], expected)
-
-        with self.assertWarnsRegex(DeprecationWarning, "signals property is deprecated"):
-            self.assertTrue(solver.signals[0] == 1.0)
 
 
 class TestSolverValidation(QiskitDynamicsTestCase):
@@ -495,6 +435,21 @@ class TestSolverSignalHandling(QiskitDynamicsTestCase):
         res2 = solve_lmde(generator=rwa_td_lindblad_model, t_span=t_span, y0=y0)
 
         self.assertAllClose(res1.y, res2.y)
+
+    def test_signals_are_None(self):
+        """Test the model signals return to being None after simulation."""
+
+        ham_solver = Solver(hamiltonian_operators=[self.X])
+        ham_solver.solve(signals=[1.0], t_span=[0.0, 0.01], y0=np.array([0.0, 1.0]))
+        self.assertTrue(ham_solver.model.signals is None)
+
+        lindblad_solver = Solver(hamiltonian_operators=[self.X], static_dissipators=[self.X])
+        lindblad_solver.solve(signals=[1.0], t_span=[0.0, 0.01], y0=np.eye(2))
+        self.assertTrue(lindblad_solver.model.signals == (None, None))
+
+        td_lindblad_solver = Solver(hamiltonian_operators=[self.X], dissipator_operators=[self.X])
+        td_lindblad_solver.solve(signals=([1.0], [1.0]), t_span=[0.0, 0.01], y0=np.eye(2))
+        self.assertTrue(td_lindblad_solver.model.signals == (None, None))
 
 
 class TestSolverSimulation(QiskitDynamicsTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #123 

### Details and comments

As per the [deprecation notes of 0.3.0](https://qiskit.org/documentation/dynamics/release_notes.html), this PR removes:
- Support for passing `carriers` as a list in `InstructionToSignals`.
- The `Solver.signals` property, and the `Solver` init kwargs `hamiltonian_signals` and `lindblad_signals`.
    - Associated with this, the `Solver.solve` method has been updated to always reset the `Solver.model` signals to `None`.
- The `Solver.copy` method has been removed.

Tests that checked for the deprecation warnings have been removed. I've added a test that verifies that the `Solver.model.signals` property is always returned to `None` (or `(None, None)` for a Lindblad model) after calling `Solver.solve`.