### PR TITLE
Fixing pulse jit bug

### DIFF
--- a/qiskit_dynamics/solvers/diffrax_solver.py
+++ b/qiskit_dynamics/solvers/diffrax_solver.py
@@ -24,8 +24,6 @@ from qiskit import QiskitError
 from qiskit_dynamics.dispatch import requires_backend
 from qiskit_dynamics.array import Array, wrap
 
-from .solver_utils import merge_t_args
-
 try:
     import jax.numpy as jnp
 except ImportError:

--- a/qiskit_dynamics/solvers/diffrax_solver.py
+++ b/qiskit_dynamics/solvers/diffrax_solver.py
@@ -63,8 +63,6 @@ def diffrax_solver(
 
     diffeqsolve = wrap(_diffeqsolve)
 
-    t_list = merge_t_args(t_span, t_eval)
-
     # convert rhs and y0 to real
     rhs = real_rhs(rhs)
     y0 = c2r(y0)
@@ -83,8 +81,8 @@ def diffrax_solver(
     results = diffeqsolve(
         term,
         solver=method,
-        t0=t_list[0],
-        t1=t_list[-1],
+        t0=t_span[0],
+        t1=t_span[-1],
         dt0=None,
         y0=Array(y0, dtype=float),
         **kwargs,

--- a/qiskit_dynamics/solvers/fixed_step_solvers.py
+++ b/qiskit_dynamics/solvers/fixed_step_solvers.py
@@ -364,7 +364,7 @@ def fixed_step_solver_template(
 
     results = OdeResult(t=t_list, y=ys)
 
-    return trim_t_results(results, t_span, t_eval)
+    return trim_t_results(results, t_eval)
 
 
 def fixed_step_solver_template_jax(
@@ -426,7 +426,7 @@ def fixed_step_solver_template_jax(
 
     results = OdeResult(t=t_list, y=ys)
 
-    return trim_t_results(results, t_span, t_eval)
+    return trim_t_results(results, t_eval)
 
 
 def fixed_step_lmde_solver_parallel_template_jax(
@@ -519,7 +519,7 @@ def fixed_step_lmde_solver_parallel_template_jax(
 
     results = OdeResult(t=t_list, y=Array(ys, backend="jax"))
 
-    return trim_t_results(results, t_span, t_eval)
+    return trim_t_results(results, t_eval)
 
 
 def get_fixed_step_sizes(t_span: Array, t_eval: Array, max_dt: float) -> Tuple[Array, Array, Array]:

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -69,5 +69,5 @@ def jax_odeint(
     )
 
     results = OdeResult(t=t_list, y=Array(results, backend="jax", dtype=complex))
-
-    return trim_t_results(results, t_span, t_eval)
+    import pdb; pdb.set_trace()
+    return trim_t_results(results, t_eval)

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -69,5 +69,5 @@ def jax_odeint(
     )
 
     results = OdeResult(t=t_list, y=Array(results, backend="jax", dtype=complex))
-    import pdb; pdb.set_trace()
+
     return trim_t_results(results, t_eval)

--- a/qiskit_dynamics/solvers/jax_odeint.py
+++ b/qiskit_dynamics/solvers/jax_odeint.py
@@ -24,7 +24,7 @@ from scipy.integrate._ivp.ivp import OdeResult
 from qiskit_dynamics.dispatch import requires_backend
 from qiskit_dynamics.array import Array, wrap
 
-from .solver_utils import merge_t_args, trim_t_results
+from .solver_utils import merge_t_args_jax, trim_t_results_jax
 
 try:
     from jax.experimental.ode import odeint as _odeint
@@ -55,7 +55,7 @@ def jax_odeint(
         OdeResult: Results object.
     """
 
-    t_list = merge_t_args(t_span, t_eval)
+    t_list = merge_t_args_jax(t_span, t_eval)
 
     # determine direction of integration
     t_direction = np.sign(Array(t_list[-1] - t_list[0], backend="jax", dtype=complex))
@@ -70,4 +70,4 @@ def jax_odeint(
 
     results = OdeResult(t=t_list, y=Array(results, backend="jax", dtype=complex))
 
-    return trim_t_results(results, t_eval)
+    return trim_t_results_jax(results, t_eval)

--- a/qiskit_dynamics/solvers/solver_classes.py
+++ b/qiskit_dynamics/solvers/solver_classes.py
@@ -47,7 +47,7 @@ from qiskit_dynamics.pulse import InstructionToSignals
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.dispatch.dispatch import Dispatch
 
-from .solver_functions import solve_lmde, _is_jax_method
+from .solver_functions import solve_lmde, _is_diffrax_method
 from .solver_utils import (
     is_lindblad_model_vectorized,
     is_lindblad_model_not_vectorized,
@@ -595,9 +595,10 @@ class Solver:
         )
 
         all_results = None
+        method = kwargs.get("method", "")
         if (
             Array.default_backend() == "jax"
-            and _is_jax_method(kwargs.get("method", ""))
+            and (method == "jax_odeint" or _is_diffrax_method(method))
             and all(isinstance(x, Schedule) for x in signals_list)
         ):
             all_results = self._solve_schedule_list_jax(

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -26,6 +26,12 @@ from qiskit import QiskitError
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.models import LindbladModel
 
+try:
+    from jax.lax import cond
+    import jax.numpy as jnp
+except ImportError:
+    pass
+
 
 def is_lindblad_model_vectorized(obj: any) -> bool:
     """Return True if obj is a vectorized LindbladModel."""
@@ -110,12 +116,64 @@ def trim_t_results(
         return results
 
     # remove endpoints
-    results.t = results.t[1:]
-    results.t = results.t[:-1]
+    results.t = results.t[1:-1]
+    results.y = Array(results.y[1:-1])
 
-    results.y = Array(results.y[1:])
-    results.y = Array(results.y[:-1])
+    return results
 
+
+def merge_t_args_jax(t_span, t_eval=None):
+    """JAX-compilable version of merge_t_args. Rather than raise errors, sets return values to
+    jnp.nan to signal errors.
+    """
+
+    if t_eval is None:
+        return Array(t_span, backend="jax")
+
+    t_span = Array(t_span, backend="jax").data
+    t_eval = Array(t_eval, backend="jax").data
+
+    out = jnp.append(jnp.append(t_span[0], t_eval), t_span[1])
+
+    # raise error if not one dimensional
+    if t_eval.ndim > 1:
+        raise ValueError("t_eval must be 1 dimensional.")
+
+    # output nan if t_eval point lies outside t_span
+    t_min = jnp.min(t_span)
+    t_max = jnp.max(t_span)
+    out = cond(
+        (jnp.min(t_eval) < t_min) | (jnp.max(t_eval) > t_max),
+        lambda s: jnp.nan * s,
+        lambda s: s,
+        out,
+    )
+
+    # output nan if t_eval and t_span have incompatible orderings
+    diff = jnp.diff(t_eval)
+    t_direction = jnp.sign(t_span[1] - t_span[0])
+    out = cond(jnp.any(t_direction * diff < 0.0), lambda s: jnp.nan * s, lambda s: s, out)
+
+    return Array(out)
+
+
+def trim_t_results_jax(results, t_eval):
+    """JAX-compilable version of trim_t_results. The cond call is necessary due to
+    a bug in odeint that only occurs if the first two time values are duplicates.
+    """
+
+    if t_eval is None:
+        return results
+
+    results.y = Array(
+        cond(
+            results.t[0] == results.t[1],
+            lambda y: jnp.append(jnp.array([y[0]]), y[2:-1], axis=0),
+            lambda y: y[1:-1],
+            Array(results.y).data,
+        )
+    )
+    results.t = Array(results.t[1:-1])
     return results
 
 

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -82,7 +82,7 @@ def merge_t_args(
 
     diff = np.diff(t_eval)
 
-    if np.any(t_direction * diff <= 0.0):
+    if np.any(t_direction * diff < 0.0):
         raise ValueError("t_eval must be ordered according to the direction of integration.")
 
     # if endpoints are not included in t_span, add them

--- a/releasenotes/notes/pulse-jit-bug-5f24ed781343225c.yaml
+++ b/releasenotes/notes/pulse-jit-bug-5f24ed781343225c.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes a bug in the automatic jit-compilation of :meth:`Solver.solve` when using
+    the `t_eval` kwarg with a JAX method and `Array.default_backend() == 'jax'`.
+    The bug is fixed by updating the time-argument handling for the cases
+    `method='jax_odeint'` or `method` being a Diffrax method. The automatic jitting is
+    disabled for all other JAX methods.

--- a/test/dynamics/solvers/test_jax_odeint.py
+++ b/test/dynamics/solvers/test_jax_odeint.py
@@ -123,5 +123,4 @@ class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
                 [1 + 0.5],
             ]
         )
-        import pdb; pdb.set_trace()
         self.assertAllClose(expected_y, results.y)

--- a/test/dynamics/solvers/test_jax_odeint.py
+++ b/test/dynamics/solvers/test_jax_odeint.py
@@ -153,4 +153,4 @@ class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
 
         jit_grad_func = self.jit_grad_wrap(lambda a: func(t_span, a)[1][-1])
         out = jit_grad_func(t_eval)
-        self.assertAllClose(out, np.array([0., 0., 1.7**2]))
+        self.assertAllClose(out, np.array([0.0, 0.0, 1.7**2]))

--- a/test/dynamics/solvers/test_jax_odeint.py
+++ b/test/dynamics/solvers/test_jax_odeint.py
@@ -123,5 +123,5 @@ class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
                 [1 + 0.5],
             ]
         )
-
+        import pdb; pdb.set_trace()
         self.assertAllClose(expected_y, results.y)

--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -1242,6 +1242,63 @@ class TestPulseSimulationJAX(TestPulseSimulation, TestJaxBase):
         super().setUp()
         self.method = "jax_odeint"
 
+    def test_t_eval_t_span_jax_odeint(self):
+        """Test internal jitting works when specifying t_eval and t_span. This catches a bug
+        that was missed on initial implementation. This test just checks that it runs,
+        with the correctness assumed to be verified elsewhere.
+        """
+
+        with pulse.build() as sched:
+            pulse.play(pulse.Constant(duration=5, amp=0.9), pulse.DriveChannel(0))
+
+        self.ham_solver.solve(
+            signals=sched,
+            t_span=[0.0, 0.1],
+            y0=np.array([0.0, 1.0]),
+            t_eval=[0.0, 0.05, 0.1],
+            method="jax_odeint",
+        )
+
+    def test_t_eval_t_span_diffrax(self):
+        """Test internal jitting works when specifying t_eval and t_span for diffrax.
+        This catches a bug that was missed on initial implementation. This test just checks
+        that it runs, with the correctness assumed to be verified elsewhere.
+        """
+
+        from diffrax import Dopri5, PIDController
+
+        with pulse.build() as sched:
+            pulse.play(pulse.Constant(duration=5, amp=0.9), pulse.DriveChannel(0))
+
+        self.ham_solver.solve(
+            signals=sched,
+            t_span=[0.0, 0.1],
+            y0=np.array([0.0, 1.0]),
+            t_eval=[0.0, 0.05, 0.1],
+            method=Dopri5(),
+            stepsize_controller=PIDController(rtol=1e-10, atol=1e-10),
+            max_steps=1000000,
+        )
+
+    def test_t_eval_t_span_jax_expm(self):
+        """Test internal jitting works when specifying t_eval and t_span for jax_expm,
+        which serves as a place-holder for internally developed fixed-step solvers.
+        This catches a bug that was missed on initial implementation. This test just checks
+        that it runs, with the correctness assumed to be verified elsewhere.
+        """
+
+        with pulse.build() as sched:
+            pulse.play(pulse.Constant(duration=5, amp=0.9), pulse.DriveChannel(0))
+
+        self.ham_solver.solve(
+            signals=sched,
+            t_span=[0.0, 0.1],
+            y0=np.array([0.0, 1.0]),
+            t_eval=[0.0, 0.05, 0.1],
+            method="jax_expm",
+            max_dt=0.05,
+        )
+
 
 @ddt
 class TestSolverListSimulation(QiskitDynamicsTestCase):

--- a/test/dynamics/solvers/test_solver_utils.py
+++ b/test/dynamics/solvers/test_solver_utils.py
@@ -19,71 +19,95 @@ Tests to convert from pulse schedules to signals.
 
 import numpy as np
 
-from qiskit_dynamics.solvers.solver_utils import merge_t_args, trim_t_results
+from qiskit_dynamics.solvers.solver_utils import (
+    merge_t_args,
+    trim_t_results,
+    merge_t_args_jax,
+    trim_t_results_jax,
+)
 
-from ..common import QiskitDynamicsTestCase
+from ..common import QiskitDynamicsTestCase, TestJaxBase
+
+try:
+    import jax.numpy as jnp
+except ImportError:
+    pass
 
 
 class TestTimeArgsHandling(QiskitDynamicsTestCase):
     """Tests for merge_t_args and trim_t_results functions."""
 
+    def merge_t_args(self, t_span, t_eval=None):
+        """Wrapper function for controlling which function is used via inheritance."""
+        return merge_t_args(t_span, t_eval)
+
+    def trim_t_results(self, results, t_eval=None):
+        """Wrapper function for controlling which function is used via inheritance."""
+        return trim_t_results(results, t_eval)
+
     def test_merge_t_args_dim_error(self):
         """Test raising of ValueError for non-1d t_eval."""
         with self.assertRaisesRegex(ValueError, "t_eval must be 1 dimensional."):
-            merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([[0.0]]))
+            self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([[0.0]]))
 
     def test_merge_t_args_interval_error(self):
         """Test raising ValueError if t_eval not in t_span."""
         with self.assertRaisesRegex(ValueError, "t_eval entries must lie in t_span."):
-            merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([1.5]))
+            self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([1.5]))
 
     def test_merge_t_args_interval_error_backwards(self):
         """Test raising ValueError if t_eval not in t_span for backwards integration."""
         with self.assertRaisesRegex(ValueError, "t_eval entries must lie in t_span."):
-            merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-1.5]))
+            self.merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-1.5]))
 
     def test_merge_t_args_sort_error(self):
         """Test raising ValueError if t_eval is not correctly sorted."""
         with self.assertRaisesRegex(ValueError, "t_eval must be ordered"):
-            merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.75, 0.25]))
+            self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.75, 0.25]))
 
     def test_merge_t_args_sort_error_backwards(self):
         """Test raising ValueError if t_eval is not correctly sorted for
         backwards integration.
         """
         with self.assertRaisesRegex(ValueError, "t_eval must be ordered"):
-            merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-0.75, -0.25]))
+            self.merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-0.75, -0.25]))
 
     def test_merge_t_args_no_overlap(self):
         """Test merging with no overlaps."""
-        times = merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.25, 0.75]))
+        times = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.25, 0.75]))
         self.assertAllClose(times, np.array([0.0, 0.25, 0.75, 1.0]))
 
     def test_merge_t_args_no_overlap_backwards(self):
         """Test merging with no overlaps for backwards integration."""
-        times = merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=-np.array([0.25, 0.75]))
+        times = self.merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=-np.array([0.25, 0.75]))
         self.assertAllClose(times, -np.array([0.0, 0.25, 0.75, 1.0]))
 
     def test_merge_t_args_with_overlap(self):
         """Test merging with with overlaps."""
-        times = merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75]))
+        times = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75]))
         self.assertAllClose(times, np.array([0.0, 0.0, 0.25, 0.75, 1.0]))
 
-        times = merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.25, 0.75, 1.0]))
+        times = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.25, 0.75, 1.0]))
         self.assertAllClose(times, np.array([0.0, 0.25, 0.75, 1.0, 1.0]))
 
-        times = merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75, 1.0]))
+        times = self.merge_t_args(
+            t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75, 1.0])
+        )
         self.assertAllClose(times, np.array([0.0, 0.0, 0.25, 0.75, 1.0, 1.0]))
 
     def test_merge_t_args_with_overlap_backwards(self):
         """Test merging with with overlaps for backwards integration."""
-        times = merge_t_args(t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75]))
+        times = self.merge_t_args(
+            t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75])
+        )
         self.assertAllClose(times, np.array([1.0, 1.0, -0.25, -0.75, -1.0]))
 
-        times = merge_t_args(t_span=np.array([1.0, -1.0]), t_eval=np.array([-0.25, -0.75, -1.0]))
+        times = self.merge_t_args(
+            t_span=np.array([1.0, -1.0]), t_eval=np.array([-0.25, -0.75, -1.0])
+        )
         self.assertAllClose(times, np.array([1.0, -0.25, -0.75, -1.0, -1.0]))
 
-        times = merge_t_args(
+        times = self.merge_t_args(
             t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75, -1.0])
         )
         self.assertAllClose(times, np.array([1.0, 1.0, -0.25, -0.75, -1.0, -1.0]))
@@ -97,9 +121,8 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
         empty_obj.t = np.array([0.0, 1.0, 2.0])
         empty_obj.y = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
 
-        t_span = np.array([0.0, 2.0])
         t_eval = np.array([1.0])
-        trimmed_obj = trim_t_results(empty_obj, t_eval)
+        trimmed_obj = self.trim_t_results(empty_obj, t_eval)
 
         self.assertAllClose(trimmed_obj.t, np.array([1.0]))
         self.assertAllClose(trimmed_obj.y, np.array([[0.5, 0.5]]))
@@ -113,9 +136,8 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
         empty_obj.t = np.array([1.0, -1.0, -2.0])
         empty_obj.y = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
 
-        t_span = np.array([1.0, -2.0])
         t_eval = np.array([-1.0])
-        trimmed_obj = trim_t_results(empty_obj, t_eval)
+        trimmed_obj = self.trim_t_results(empty_obj, t_eval)
 
         self.assertAllClose(trimmed_obj.t, np.array([-1.0]))
         self.assertAllClose(trimmed_obj.y, np.array([[0.5, 0.5]]))
@@ -129,9 +151,62 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
         empty_obj.t = np.array([0.0, 1.0, 2.0])
         empty_obj.y = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
 
-        t_span = np.array([0.0, 2.0])
         t_eval = None
-        trimmed_obj = trim_t_results(empty_obj, t_eval)
+        trimmed_obj = self.trim_t_results(empty_obj, t_eval)
 
         self.assertAllClose(trimmed_obj.t, np.array([0.0, 1.0, 2.0]))
         self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]]))
+
+
+class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
+    """Tests for merge_t_args_jax and trim_t_results_jax functions."""
+
+    def merge_t_args(self, t_span, t_eval=None):
+        return merge_t_args_jax(t_span, t_eval)
+
+    def trim_t_results(self, results, t_eval=None):
+        return trim_t_results_jax(results, t_eval)
+
+    def test_merge_t_args_interval_error(self):
+        """Test output nan if t_eval not in t_span."""
+        out = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([1.5]))
+        self.assertTrue(jnp.isnan(out.data).all())
+        self.assertTrue(out.shape == (3,))
+
+    def test_merge_t_args_interval_error_backwards(self):
+        """Test output nan if t_eval not in t_span for backwards integration."""
+        out = self.merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-1.5]))
+        self.assertTrue(jnp.isnan(out.data).all())
+        self.assertTrue(out.shape == (3,))
+
+    def test_merge_t_args_sort_error(self):
+        """Test output nan if t_eval is not correctly sorted."""
+        out = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.75, 0.25]))
+        self.assertTrue(jnp.isnan(out.data).all())
+        self.assertTrue(out.shape == (4,))
+
+    def test_merge_t_args_sort_error_backwards(self):
+        """Test raising ValueError if t_eval is not correctly sorted for
+        backwards integration.
+        """
+        out = self.merge_t_args(t_span=np.array([0.0, -1.0]), t_eval=np.array([-0.75, -0.25]))
+        self.assertTrue(jnp.isnan(out.data).all())
+        self.assertTrue(out.shape == (4,))
+
+    def test_trim_t_results_t0_duplicate(self):
+        """Test trim_t_results_jax with duplicate in first time entry. Verifies that the first state
+        for the corresponding time is kept. Due to a peculiarity in jax_odeint, the second will
+        be nan (but only for the first time entry).
+        """
+
+        # empty object to assign attributes to
+        empty_obj = type("", (), {})()
+
+        empty_obj.t = np.array([0.0, 0.0, 1.0, 2.0])
+        empty_obj.y = np.array([[0.0, 1.0], [1.0, 0.0], [0.5, 0.5], [1.0, 0.0]])
+
+        t_eval = np.array([0.0, 1.0])
+        trimmed_obj = self.trim_t_results(empty_obj, t_eval)
+
+        self.assertAllClose(trimmed_obj.t, np.array([0.0, 1.0]))
+        self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5]]))

--- a/test/dynamics/solvers/test_solver_utils.py
+++ b/test/dynamics/solvers/test_solver_utils.py
@@ -67,61 +67,29 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
     def test_merge_t_args_with_overlap(self):
         """Test merging with with overlaps."""
         times = merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75]))
-        self.assertAllClose(times, np.array([0.0, 0.25, 0.75, 1.0]))
+        self.assertAllClose(times, np.array([0.0, 0.0, 0.25, 0.75, 1.0]))
 
         times = merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.25, 0.75, 1.0]))
-        self.assertAllClose(times, np.array([0.0, 0.25, 0.75, 1.0]))
+        self.assertAllClose(times, np.array([0.0, 0.25, 0.75, 1.0, 1.0]))
 
         times = merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75, 1.0]))
-        self.assertAllClose(times, np.array([0.0, 0.25, 0.75, 1.0]))
+        self.assertAllClose(times, np.array([0.0, 0.0, 0.25, 0.75, 1.0, 1.0]))
 
     def test_merge_t_args_with_overlap_backwards(self):
         """Test merging with with overlaps for backwards integration."""
         times = merge_t_args(t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75]))
-        self.assertAllClose(times, np.array([1.0, -0.25, -0.75, -1.0]))
+        self.assertAllClose(times, np.array([1.0, 1.0, -0.25, -0.75, -1.0]))
 
         times = merge_t_args(t_span=np.array([1.0, -1.0]), t_eval=np.array([-0.25, -0.75, -1.0]))
-        self.assertAllClose(times, np.array([1.0, -0.25, -0.75, -1.0]))
+        self.assertAllClose(times, np.array([1.0, -0.25, -0.75, -1.0, -1.0]))
 
         times = merge_t_args(
             t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75, -1.0])
         )
-        self.assertAllClose(times, np.array([1.0, -0.25, -0.75, -1.0]))
+        self.assertAllClose(times, np.array([1.0, 1.0, -0.25, -0.75, -1.0, -1.0]))
 
-    def test_trim_t_results_overlap(self):
-        """Test trim_t_results does nothing if endpoints are in t_eval."""
-
-        # empty object to assign attributes to
-        empty_obj = type("", (), {})()
-
-        empty_obj.t = np.array([0.0, 1.0, 2.0])
-        empty_obj.y = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
-
-        t_span = np.array([0.0, 2.0])
-        t_eval = np.array([0.0, 1.0, 2.0])
-        trimmed_obj = trim_t_results(empty_obj, t_span, t_eval)
-
-        self.assertAllClose(trimmed_obj.t, np.array([0.0, 1.0, 2.0]))
-        self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]]))
-
-    def test_trim_t_results_overlap_backwards(self):
-        """Test trim_t_results does nothing if endpoints are in t_eval for backwards integration."""
-
-        # empty object to assign attributes to
-        empty_obj = type("", (), {})()
-
-        empty_obj.t = np.array([1.0, -1.0, -2.0])
-        empty_obj.y = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
-
-        t_span = np.array([1.0, -2.0])
-        t_eval = np.array([1.0, -1.0, -2.0])
-        trimmed_obj = trim_t_results(empty_obj, t_span, t_eval)
-
-        self.assertAllClose(trimmed_obj.t, np.array([1.0, -1.0, -2.0]))
-        self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]]))
-
-    def test_trim_t_results_no_overlap(self):
-        """Test trim_t_results removes endpoints if not in t_eval."""
+    def test_trim_t_results(self):
+        """Test trim_t_results works if t_eval is not None."""
 
         # empty object to assign attributes to
         empty_obj = type("", (), {})()
@@ -131,23 +99,39 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
 
         t_span = np.array([0.0, 2.0])
         t_eval = np.array([1.0])
-        trimmed_obj = trim_t_results(empty_obj, t_span, t_eval)
+        trimmed_obj = trim_t_results(empty_obj, t_eval)
 
         self.assertAllClose(trimmed_obj.t, np.array([1.0]))
         self.assertAllClose(trimmed_obj.y, np.array([[0.5, 0.5]]))
 
-    def test_trim_t_results_no_overlap_backwards(self):
-        """Test trim_t_results removes endpoints if not in t_eval for backwards integration."""
+    def test_trim_t_results_backwards(self):
+        """Test trim_t_results works if t_eval is not None and backwards integration."""
 
         # empty object to assign attributes to
         empty_obj = type("", (), {})()
 
-        empty_obj.t = np.array([0.0, -1.0, -2.0])
+        empty_obj.t = np.array([1.0, -1.0, -2.0])
         empty_obj.y = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
 
-        t_span = np.array([0.0, -2.0])
+        t_span = np.array([1.0, -2.0])
         t_eval = np.array([-1.0])
-        trimmed_obj = trim_t_results(empty_obj, t_span, t_eval)
+        trimmed_obj = trim_t_results(empty_obj, t_eval)
 
         self.assertAllClose(trimmed_obj.t, np.array([-1.0]))
         self.assertAllClose(trimmed_obj.y, np.array([[0.5, 0.5]]))
+
+    def test_trim_t_results_t_eval_is_None(self):
+        """Test trim_t_results when t_eval is None."""
+
+        # empty object to assign attributes to
+        empty_obj = type("", (), {})()
+
+        empty_obj.t = np.array([0.0, 1.0, 2.0])
+        empty_obj.y = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
+
+        t_span = np.array([0.0, 2.0])
+        t_eval = None
+        trimmed_obj = trim_t_results(empty_obj, t_eval)
+
+        self.assertAllClose(trimmed_obj.t, np.array([0.0, 1.0, 2.0]))
+        self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]]))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #122.

See the discussion in #122 for a summary of the bug including technical details. This PR fixes the bug by taking the following actions (described in [this comment](https://github.com/Qiskit/qiskit-dynamics/issues/122#issuecomment-1232177882)):
- The bug for `method='jax_odeint'` has been fixed by updating the internal time-value handling of `jax_odeint`.
- The bug for `method` being a diffrax solver has been fixed with minimal changes. (It was using the problematic time-handling functions, but this was actually unnecessary as `diffrax` is able to take care of these things itself, so dynamics doesn't need to deal with it.)
- The bug for `method` being a dynamics-based fixed-step solver is now avoided by making it so that the automatic jitting behaviour is only triggered in the above two cases. (There isn't a simple "fix" for making the jitting work for these solvers.)

### Details and comments

The following changes have been made:
- Tests for `Solver` have been added that trigger the errors described in #122 (which are now passing).
- For diffrax solver fix:
    - Removed unnecessary call to `merge_t_args`
- For jax_odeint:
    - Modified `merge_t_args` and `trim_t_args` to always append/remove the endpoints. The original logic was to check if any end points of `t_eval` and `t_span` were the same, and if yes it wouldn't append/remove time points where appropriate. I realized that this special handling is not actually necessary, it is fine to always add/remove the endpoints.
    - Added `merge_t_args_jax` and `trim_t_args_jax` to be the JAX-compilable versions of these functions. To do compilable validation, most validation checks in `merge_t_args_jax` are now written with JAX conditionals. If a validation check fails, the output will be full of `nan` values. Unfortunately this is the only way to "raise an error" in a JAX compilable way.
    - Modified tests for `merge_t_args` and `trim_t_args` to check for the updated behaviour.
    - Added tests for `merge_t_args_jax` and `trim_t_arg_jax`, utilizing inheritance from the non-JAX test cases to limit number of lines.
    - Updated `jax_odeint` to use the JAX versions of these functions.
    - Added test case for `jax_odeint` that validates we can compile/differentiate functions that take both `t_span` and `t_eval` as inputs.
- To avoid bug for fixed step solvers:
    - Updated `Solver.solve` to only do the automatic compilation when the method is either `jax_odeint` or a diffrax solver.