### PR TITLE
Removing 'Solvers' from sphinx project name

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ Sphinx documentation builder
 
 # General options:
 
-project = 'Qiskit Dynamics Solvers'
+project = 'Qiskit Dynamics'
 copyright = '2020, Qiskit Development Team'  # pylint: disable=redefined-builtin
 author = 'Qiskit Development Team'
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Noticed that the documentation page if you google "Qiskit Dynamics" says "Qiskit Dynamics Solvers". Changed the project name in the sphinx `conf.py` file from "Qiskit Dynamics Solvers" to "Qiskit Dynamics" to fix this.

