### PR TITLE
Fix bugs introduced by dependency updates

### DIFF
--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -101,7 +101,7 @@ class Signal:
                 self._is_constant = True
 
             if envelope.backend == "jax":
-                self._envelope = lambda t: envelope * jnp.ones_like(t)
+                self._envelope = lambda t: envelope * jnp.ones_like(Array(t).data)
             else:
                 self._envelope = lambda t: envelope * np.ones_like(t)
         elif callable(envelope):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ astroid==2.9.3
 pylint==2.12.2
 black~=22.0
 qiskit-sphinx-theme>=1.6
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints~=1.18,!=1.19.3
 jupyter-sphinx
 pygments>=2.4
 reno>=3.4.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The tests and docs have broken without any changes to the code, so presumably due to dependency updates.

### Details

JAX updates broke the tests, but fixed by changing 1 line: The function `jnp.ones_like` no longer works on `Array` objects. This PR fixes our single usage of them. Tests now working.

@mtreinish pointed out that docs build was failing due to an update to , so this PR pins it to a version that works, as per [this commit to Terra](https://github.com/Qiskit/qiskit-terra/commit/df599dc9b189fe6d027386d989d19c3946a1476a).
