### PR TITLE
Fix after latest JAX update

### DIFF
--- a/test/dynamics/solvers/test_solver_classes.py
+++ b/test/dynamics/solvers/test_solver_classes.py
@@ -937,7 +937,7 @@ class TestPulseSimulation(QiskitDynamicsTestCase):
             y0=SuperOp(np.eye(4, dtype=complex)),
             schedules=sched,
             signals=signals,
-            test_tol=1e-9,
+            test_tol=1e-8,
             atol=1e-12,
             rtol=1e-12,
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Weirdly, the latest JAX update broke a numerical comparison in one of the tests. The latest update caused numerically compared values to differ by slightly more than the comparison tolerance. It's somewhat disconcerting, but it's also okay as if we lower the simulation tolerance used to generate the arrays the go back to being below the comparison tolerance. It's possible that something they changed had an impact on some rounding errors.

To fix this, I slightly increased the comparison tolerance, rather than decrease the simulation tolerance. (I made this choice to avoid increasing the time the tests take to run.)
