### PR TITLE
Documentation cleanup in the array folder

### DIFF
--- a/qiskit_dynamics/array/__init__.py
+++ b/qiskit_dynamics/array/__init__.py
@@ -19,21 +19,20 @@ Array Module (:mod:`qiskit_dynamics.array`)
 
 .. currentmodule:: qiskit_dynamics.array
 
-This module contains an :class:`Array` class that wraps N-dimensional array
-objects from different libraries for use with NumPy functions through a common
-interface and functions for working with Array objects and other libraries.
+This module contains an :class:`Array` class that wraps N-dimensional array objects from different
+libraries for use with NumPy functions through a common interface and functions for working with
+Array objects and other libraries.
 
 Array Class
 ===========
 
-The :class:`Array` class provides a NumPy compatible wrapper to supported Python
-array libraries. When applying NumPy functions to the array class these will be
-dispatched to the corresponding function for the current Array backend, if a
-compatible function has been specified in the :mod:`qiskit_dynamics.dispatch`
-system.
+The :class:`Array` class provides a NumPy compatible wrapper to supported Python array libraries.
+When applying NumPy functions to the array class these will be dispatched to the corresponding
+function for the current Array backend, if a compatible function has been specified in the
+:mod:`qiskit_dynamics.dispatch` system.
 
 The following array libraries have built in support for the
-:mod:`qiskit_dynamics.dispatch` module
+:mod:`qiskit_dynamics.dispatch` module:
 
 * `NumPy <https://numpy.org/>`_
 * `JAX <https://github.com/google/jax>`_
@@ -41,10 +40,9 @@ The following array libraries have built in support for the
 Basic Usage
 -----------
 
-When using the default ``numpy`` backend, :class:`Array` objects can be used
-interchangably with ``numpy.ndarray``. When ``numpy`` functions are applied to
-an :class:`Array` object the return type will be an :class:`Array`
-instead of an ``ndarray``
+When using the default ``numpy`` backend :class:`Array`, objects can be used interchangably with
+``numpy.ndarray``. When ``numpy`` functions are applied to an :class:`Array` object the return type
+will be an :class:`Array` instead of an ``numpy.ndarray``.
 
 .. jupyter-execute::
 
@@ -57,36 +55,33 @@ instead of an ``ndarray``
     # Apply numpy ufuncs
     np.cos(a) + 1j * np.sin(a)
 
-For the JAX Array backend, only NumPy functions that have a corresponding function
-in the ``jax`` library that has been registered with the dispatch module can be
-applied to the functions. Trying to apply an unsupported ``numpy`` function to
-these arrays will raise an exception.
+For the JAX Array backend, only Numpy functions that have a corresponding function in the ``jax``
+library that has been registed with the dispatch module can be applied to the functions. Trying to
+apply an unsupported ``numpy`` function to these arrays will raise an exception.
 
 Default Backend
 ---------------
 
-When initializing a new :class:`Array`, the ``backend`` kwarg is used to specify
-the array backend. This will convert the input data to an array of this backend
-if required. If ``backend=None``, the default backend will be used.
-The initial default backend is always set to ``"numpy"``.
+When initializing a new :class:`Array`, the ``backend`` kwarg is used to specify which array backend
+to use. This will convert the input data to an array of this backend if required. If
+``backend=None``, the default backend will be used. The initial default backend is always set to
+``"numpy"``.
 
-The current default backend can be viewed by using the class method
-:meth:`Array.default_backend`. A different
-default backend can be set for all :meth:`Array` instances by using the
+The current default backend can be viewed by using the class method :meth:`Array.default_backend`. A
+different default backend can be set for all :meth:`Array` instances by using the
 :meth:`Array.set_default_backend` class method.
 
 Attributes and Methods
 ----------------------
 
-The :class:`Array` class exposes the same methods and attributes of the wrapped
-array class and adds two additional attributes
+The :class:`Array` class exposes the same methods and attributes of the wrapped array class and adds
+two additional attributes:
 
 * :attr:`~Array.data` which returns the wrapped array object
 * :attr:`~Array.backend` which returns the backend string of the wrapped array.
 
-All other attributes and methods of the wrapped array are accessable
-through this class, but with any array return types wrapped into
-:class:`Array` objects. For example
+All other attributes and methods of the wrapped array are accessible through this class, but with
+any array return types wrapped into :class:`Array` objects. For example
 
 .. jupyter-execute::
 
@@ -94,16 +89,15 @@ through this class, but with any array return types wrapped into
     a.reshape((2, 5))
 
 
-
 Array Initialization
 --------------------
 
-An :class:`Array` object can be initialized as ``Array(data)`` from any ``data`` that is
+An :class:`Array` object can be initialized as ``Array(data)`` from any ``data`` that is:
 
-1. An ``array`` object of one of the supported backends.
+1. An :class:`Array` object of one of the supported backends.
 2. An object that can be used to initialize the backend array.
 3. An object of a class that defines a ``__qiskit_array__`` method with the
-   following signature
+   following signature:
 
     .. code-block:: python
 
@@ -112,18 +106,16 @@ An :class:`Array` object can be initialized as ``Array(data)`` from any ``data``
                              backend: Optional[str]=None) -> Array:
             # conversion from class to Array
 
-The :meth:`Array.__init__` method has optional kwargs
+The :meth:`Array.__init__` method has optional kwargs:
 
-* ``dtype`` (``any``): Equivalent to the ``numpy.array`` ``dtype`` kwarg.
-  For other array backends the specified dtype must be supported on the
-  array backend. If not specified the dytpe will be inferred from the
-  input data.
-* ``order`` (``str``): Equivalent to the ``numpy.array`` ``order`` kwarg.
-  For other array backendsthe specified order value must be supported on
-  the array backend.
-* ``backend`` (``str``): The array backend to use. If not specified this
-  will be inferred from the input data type if it is a backend array
-  instance, otherwise it will be the :func:`default_backend`.
+* ``dtype`` (``any``): Equivalent to the ``numpy.array`` ``dtype`` kwarg. For other array backends,
+  the specified dtype must be supported on the array backend. If not specified, the ``dytpe`` will
+  be inferred from the input data.
+* ``order`` (``str``): Equivalent to the ``numpy.array`` ``order`` kwarg. For other array
+  backendsthe specified order value must be supported on the array backend.
+* ``backend`` (``str``): The array backend to use. If not specified this will be inferred from the
+  input data type if it is a backend array instance, otherwise it will be the
+  :func:`default_backend`.
 
 
 Using Arrays with other Libraries

--- a/qiskit_dynamics/array/__init__.py
+++ b/qiskit_dynamics/array/__init__.py
@@ -113,7 +113,7 @@ The :meth:`Array.__init__` method has optional kwargs:
   the specified dtype must be supported on the array backend. If not specified, the ``dytpe`` will
   be inferred from the input data.
 * ``order`` (``str``): Equivalent to the ``numpy.array`` ``order`` kwarg. For other array
-  backendsthe specified order value must be supported on the array backend.
+  backends, the specified order value must be supported.
 * ``backend`` (``str``): The array backend to use. If not specified this will be inferred from the
   input data type if it is a backend array instance, otherwise it will be the
   :func:`default_backend`.

--- a/qiskit_dynamics/array/__init__.py
+++ b/qiskit_dynamics/array/__init__.py
@@ -23,6 +23,7 @@ This module contains an :class:`Array` class that wraps N-dimensional array obje
 libraries for use with NumPy functions through a common interface and functions for working with
 Array objects and other libraries.
 
+
 Array Class
 ===========
 
@@ -81,7 +82,7 @@ two additional attributes:
 * :attr:`~Array.backend` which returns the backend string of the wrapped array.
 
 All other attributes and methods of the wrapped array are accessible through this class, but with
-any array return types wrapped into :class:`Array` objects. For example
+any array return types wrapped into :class:`Array` objects. For example:
 
 .. jupyter-execute::
 

--- a/qiskit_dynamics/array/__init__.py
+++ b/qiskit_dynamics/array/__init__.py
@@ -57,7 +57,7 @@ will be an :class:`Array` instead of an ``numpy.ndarray``.
     np.cos(a) + 1j * np.sin(a)
 
 For the JAX Array backend, only Numpy functions that have a corresponding function in the ``jax``
-library that has been registed with the dispatch module can be applied to the functions. Trying to
+library that have been registered with the dispatch module can be applied to the functions. Trying to
 apply an unsupported ``numpy`` function to these arrays will raise an exception.
 
 Default Backend

--- a/qiskit_dynamics/array/__init__.py
+++ b/qiskit_dynamics/array/__init__.py
@@ -28,7 +28,7 @@ Array Class
 ===========
 
 The :class:`Array` class provides a NumPy compatible wrapper to supported Python array libraries.
-When applying NumPy functions to the array class these will be dispatched to the corresponding
+NumPy functions applied to an :class:`Array` class instance will be dispatched to the corresponding
 function for the current Array backend, if a compatible function has been specified in the
 :mod:`qiskit_dynamics.dispatch` system.
 

--- a/qiskit_dynamics/array/__init__.py
+++ b/qiskit_dynamics/array/__init__.py
@@ -20,7 +20,7 @@ Array Module (:mod:`qiskit_dynamics.array`)
 .. currentmodule:: qiskit_dynamics.array
 
 This module contains an :class:`Array` class that wraps N-dimensional array objects from different
-libraries. It enables working with different array libraries through a common NumPy-based interface, 
+libraries. It enables working with different array libraries through a common NumPy-based interface,
 along with other functionality for writing array-library agnostic code.
 
 
@@ -57,8 +57,8 @@ will be an :class:`Array` instead of an ``numpy.ndarray``.
     np.cos(a) + 1j * np.sin(a)
 
 For the JAX Array backend, only Numpy functions that have a corresponding function in the ``jax``
-library that have been registered with the dispatch module can be applied to the functions. Trying to
-apply an unsupported ``numpy`` function to these arrays will raise an exception.
+library that have been registered with the dispatch module can be applied to the functions. Trying
+to apply an unsupported ``numpy`` function to these arrays will raise an exception.
 
 Default Backend
 ---------------

--- a/qiskit_dynamics/array/__init__.py
+++ b/qiskit_dynamics/array/__init__.py
@@ -20,8 +20,8 @@ Array Module (:mod:`qiskit_dynamics.array`)
 .. currentmodule:: qiskit_dynamics.array
 
 This module contains an :class:`Array` class that wraps N-dimensional array objects from different
-libraries for use with NumPy functions through a common interface and functions for working with
-Array objects and other libraries.
+libraries. It enables working with different array libraries through a common NumPy-based interface, 
+along with other functionality for writing array-library agnostic code.
 
 
 Array Class
@@ -95,7 +95,7 @@ Array Initialization
 
 An :class:`Array` object can be initialized as ``Array(data)`` from any ``data`` that is:
 
-1. An :class:`Array` object of one of the supported backends.
+1. An ``array`` object of one of the supported backends.
 2. An object that can be used to initialize the backend array.
 3. An object of a class that defines a ``__qiskit_array__`` method with the
    following signature:

--- a/qiskit_dynamics/array/__init__.py
+++ b/qiskit_dynamics/array/__init__.py
@@ -110,7 +110,7 @@ An :class:`Array` object can be initialized as ``Array(data)`` from any ``data``
 The :meth:`Array.__init__` method has optional kwargs:
 
 * ``dtype`` (``any``): Equivalent to the ``numpy.array`` ``dtype`` kwarg. For other array backends,
-  the specified dtype must be supported on the array backend. If not specified, the ``dytpe`` will
+  the specified ``dtype`` must be supported. If not specified, the ``dtype`` will
   be inferred from the input data.
 * ``order`` (``str``): Equivalent to the ``numpy.array`` ``order`` kwarg. For other array
   backends, the specified order value must be supported.

--- a/qiskit_dynamics/array/array.py
+++ b/qiskit_dynamics/array/array.py
@@ -9,12 +9,13 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
 """Array Class"""
 
 import copy
 from functools import wraps
 from types import BuiltinMethodType, MethodType
-from typing import Optional, Union, Tuple, Set
+from typing import Any, Optional, Union, Tuple, Set
 from numbers import Number
 
 import numpy
@@ -26,34 +27,33 @@ __all__ = ["Array"]
 
 
 class Array(NDArrayOperatorsMixin):
-    """Qiskit Array class.
+    """Qiskit array class.
 
-    This class provides a NumPy compatible wrapper to supported Python
-    array libraries. Supported backends are ``numpy`` and ``jax``.
+    This class provides a Numpy compatible wrapper to supported Python array libraries. Supported
+    backends are ``"numpy"`` and ``"jax"``.
     """
 
     def __init__(
         self,
-        data: any,
-        dtype: Optional[any] = None,
+        data: Any,
+        dtype: Optional[Any] = None,
         order: Optional[str] = None,
         backend: Optional[str] = None,
     ):
-        """Initialize an Array container.
+        """Initialize an :class:`Array` container.
 
         Args:
-            data: An array_like input. This can be an object of any type
-                  supported by the registered `asarray` method for the
-                  specified backend.
-            dtype: Optional. The dtype of the returned array. This value
-                   must be supported by the specified array backend.
-            order: Optional. The array order. This value must be supported
-                   by the specified array backend.
-            backend: A registered array backend name. If None the
-                     default array backend will be used.
+            data: An ``array_like`` input. This can be an object of any type supported by the
+                  registered :math:`asarray` method for the specified backend.
+            dtype: Optional. The dtype of the returned array. This value must be supported by the
+                   specified array backend.
+            order: Optional. The array order. This value must be supported by the specified array
+                   backend.
+            backend: A registered array backend name. If ``None`` the default array backend will
+                     be used.
 
         Raises:
-            ValueError: if input cannot be converted to an Array.
+            ValueError: If input cannot be converted to an :class:`Array`.
         """
 
         # Check if we can override setattr and
@@ -87,7 +87,7 @@ class Array(NDArrayOperatorsMixin):
 
     @property
     def data(self):
-        """Return the wrapped array data object."""
+        """The wrapped array data object."""
         return self._data
 
     @data.setter
@@ -97,7 +97,7 @@ class Array(NDArrayOperatorsMixin):
 
     @property
     def backend(self):
-        """Return the backend of the wrapped array class."""
+        """The backend of the wrapped array class."""
         return self._backend
 
     @backend.setter
@@ -150,23 +150,23 @@ class Array(NDArrayOperatorsMixin):
         self._backend = state["_backend"]
         self._data = state["_data"]
 
-    def __getitem__(self, key: str) -> any:
-        """Return value from wrapped array"""
+    def __getitem__(self, key: str) -> Any:
+        """Return value from wrapped array."""
         return self._data[key]
 
-    def __setitem__(self, key: str, value: any):
-        """Return value of wrapped array"""
+    def __setitem__(self, key: str, value: Any):
+        """Return value of wrapped array."""
         self._data[key] = value
 
-    def __setattr__(self, name: str, value: any):
+    def __setattr__(self, name: str, value: Any):
         """Set attribute of wrapped array."""
         if name in ("_data", "data", "_backend", "backend"):
             super().__setattr__(name, value)
         else:
             setattr(self._data, name, value)
 
-    def __getattr__(self, name: str) -> any:
-        """Get attribute of wrapped array and convert to an Array."""
+    def __getattr__(self, name: str) -> Any:
+        """Get attribute of wrapped array and convert to an :class:`Array`."""
         # Call attribute on inner array object
         attr = getattr(self._data, name)
 
@@ -204,24 +204,24 @@ class Array(NDArrayOperatorsMixin):
     def __int__(self):
         """Convert size 1 array to an int."""
         if numpy.size(self) != 1:
-            raise TypeError("only size-1 Arrays can be converted to Python scalars")
+            raise TypeError("only size-1 Arrays can be converted to Python scalars.")
         return int(self._data)
 
     def __float__(self):
         """Convert size 1 array to a float."""
         if numpy.size(self) != 1:
-            raise TypeError("only size-1 Arrays can be converted to Python scalars")
+            raise TypeError("only size-1 Arrays can be converted to Python scalars.")
         return float(self._data)
 
     def __complex__(self):
         """Convert size 1 array to a complex."""
         if numpy.size(self) != 1:
-            raise TypeError("only size-1 Arrays can be converted to Python scalars")
+            raise TypeError("only size-1 Arrays can be converted to Python scalars.")
         return complex(self._data)
 
     @staticmethod
-    def _wrap(obj: Union[any, Tuple[any]], backend: Optional[str] = None) -> Union[any, Tuple[any]]:
-        """Wrap return array backend objects as Array objects"""
+    def _wrap(obj: Union[Any, Tuple[Any]], backend: Optional[str] = None) -> Union[Any, Tuple[Any]]:
+        """Wrap return array backend objects as :class:`Array` objects."""
         if isinstance(obj, tuple):
             return tuple(
                 Array(x, backend=backend) if isinstance(x, Dispatch.REGISTERED_TYPES) else x
@@ -233,7 +233,7 @@ class Array(NDArrayOperatorsMixin):
 
     @classmethod
     def _unwrap(cls, obj):
-        """Unwrap an Array or list of Array objects"""
+        """Unwrap an Array or list of :class:`Array` objects."""
         if isinstance(obj, Array):
             return obj._data
         if isinstance(obj, tuple):
@@ -243,7 +243,7 @@ class Array(NDArrayOperatorsMixin):
         return obj
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        """Dispatcher for numpy ufuncs to support the wrapped array backend."""
+        """Dispatcher for NumPy ufuncs to support the wrapped array backend."""
         out = kwargs.get("out", tuple())
 
         for i in inputs + out:
@@ -274,7 +274,7 @@ class Array(NDArrayOperatorsMixin):
         return self._wrap(result, backend=self.backend)
 
     def __array_function__(self, func, types, args, kwargs):
-        """Dispatcher for numpy array function to support the wrapped array backend."""
+        """Dispatcher for NumPy array function to support the wrapped :class:`Array` backend."""
         if not all(issubclass(t, (Array,) + Dispatch.REGISTERED_TYPES) for t in types):
             return NotImplemented
 
@@ -297,7 +297,7 @@ def _is_numpy_backend(backend: Optional[str] = None):
     return backend == "numpy" or (not backend and Dispatch.DEFAULT_BACKEND == "numpy")
 
 
-def _is_equivalent_numpy_array(data: any, dtype: Optional[any] = None, order: Optional[str] = None):
+def _is_equivalent_numpy_array(data: Any, dtype: Optional[Any] = None, order: Optional[str] = None):
     return (not dtype or dtype == data.dtype) and (
         not order
         or (order == "C" and data.flags["C_CONTIGUOUS"])

--- a/qiskit_dynamics/array/wrap.py
+++ b/qiskit_dynamics/array/wrap.py
@@ -9,7 +9,8 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-"""Functions for working with Array dispatch."""
+
+"""Functions for working with :class:`Array` dispatch."""
 
 import functools
 from types import FunctionType
@@ -21,16 +22,15 @@ from .array import Array
 def wrap(
     func: Callable, wrap_return: bool = True, wrap_args: bool = True, decorator: bool = False
 ) -> Callable:
-    """Wrap an array backend function to work with Arrays.
+    r"""Wrap an array backend function to work with :class:`Array`\s.
 
     Args:
-        func: a function to wrap.
-        wrap_return: If ``True`` convert results that are registered array
-                     backend types into Array objects (Default: True).
-        wrap_args: If ``True`` also wrap function type args and kwargs of the
-                   wrapped function.
-        decorator: If ``True`` the wrapped decorator function ``func`` will
-                   also wrap the decorated functions (Default: False).
+        func: A function to wrap.
+        wrap_return: If ``True`` convert results that are registered array backend types into
+                     :class:`Array` objects.
+        wrap_args: If ``True`` also wrap function type args and kwargs of the wrapped function.
+        decorator: If ``True`` the wrapped decorator function ``func`` will also wrap the
+                   decorated functions.
 
     Returns:
         Callable: The wrapped function.
@@ -42,7 +42,7 @@ def wrap(
 
 
 def _wrap_array_function(func: Callable) -> Callable:
-    """Wrap a function to handle Array-like inputs and returns."""
+    r"""Wrap a function to handle :class:`Array`\-like inputs and returns."""
 
     @functools.wraps(func)
     def wrapped_function(*args, **kwargs):
@@ -85,14 +85,13 @@ def _wrap_kwargs(kwargs):
 
 
 def _wrap_function(func: Callable, wrap_return: bool = True, wrap_args: bool = True) -> Callable:
-    """Wrap an array backend function to work with Arrays.
+    r"""Wrap an array backend function to work with :class:`Array`\s.
 
     Args:
-        func: a function to wrap.
-        wrap_return: If ``True`` convert results that are registered array
-                     backend types into Array objects (Default: True).
-        wrap_args: If ``True`` also wrap function type args and kwargs of the
-                   wrapped function.
+        func: A function to wrap.
+        wrap_return: If ``True`` convert results that are registered array backend types into
+                     :class:`Array` objects.
+        wrap_args: If ``True`` also wrap function type args and kwargs of the wrapped function.
 
     Returns:
         Callable: The wrapped function.
@@ -138,14 +137,13 @@ def _wrap_function(func: Callable, wrap_return: bool = True, wrap_args: bool = T
 
 
 def _wrap_decorator(func: Callable, wrap_return: bool = True, wrap_args: bool = True) -> Callable:
-    """Wrap a function decorator to work with Arrays.
+    r"""Wrap a function decorator to work with :class:`Array`\s.
 
     Args:
-        func: a function to wrap.
-        wrap_return: If ``True`` convert results that are registered array
-                     backend types into Array objects (Default: True).
-        wrap_args: If ``True`` also wrap function type args and kwargs of the
-                   wrapped function.
+        func: A function to wrap.
+        wrap_return: If ``True`` convert results that are registered array backend types into
+                     :class:`Array` objects.
+        wrap_args: If ``True`` also wrap function type args and kwargs of the wrapped function.
 
     Returns:
         Callable: The wrapped function.


### PR DESCRIPTION
### Summary

This PR has documentation fixes for the array folder.

### Details and comments

- Wrap to 100 characters
- builtins.any -> typing.Any
- Add sphinx references when absent
- Typos and grammar
