### PR TITLE
Fix scipy.sparse.csr import warnings

### DIFF
--- a/qiskit_dynamics/models/generator_model.py
+++ b/qiskit_dynamics/models/generator_model.py
@@ -20,8 +20,7 @@ from typing import Tuple, Union, List, Optional
 from warnings import warn
 from copy import copy
 import numpy as np
-from scipy.sparse import csr_matrix
-from scipy.sparse import issparse, diags
+from scipy.sparse import csr_matrix, issparse, diags
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator

--- a/qiskit_dynamics/models/generator_model.py
+++ b/qiskit_dynamics/models/generator_model.py
@@ -20,7 +20,7 @@ from typing import Tuple, Union, List, Optional
 from warnings import warn
 from copy import copy
 import numpy as np
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 from scipy.sparse import issparse, diags
 
 from qiskit import QiskitError

--- a/qiskit_dynamics/models/hamiltonian_model.py
+++ b/qiskit_dynamics/models/hamiltonian_model.py
@@ -18,7 +18,7 @@ Hamiltonian models module.
 from typing import Union, List, Optional
 import numpy as np
 from scipy.sparse import issparse
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 from scipy.sparse.linalg import norm as spnorm
 
 from qiskit import QiskitError

--- a/qiskit_dynamics/models/hamiltonian_model.py
+++ b/qiskit_dynamics/models/hamiltonian_model.py
@@ -17,8 +17,7 @@ Hamiltonian models module.
 
 from typing import Union, List, Optional
 import numpy as np
-from scipy.sparse import issparse
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, issparse
 from scipy.sparse.linalg import norm as spnorm
 
 from qiskit import QiskitError

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -17,7 +17,7 @@ Lindblad models module.
 
 from typing import Tuple, Union, List, Optional
 from warnings import warn
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -16,8 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Union, List, Optional
 from copy import copy
 import numpy as np
-from scipy.sparse import issparse
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, issparse
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators.operator import Operator

--- a/qiskit_dynamics/models/operator_collections.py
+++ b/qiskit_dynamics/models/operator_collections.py
@@ -17,7 +17,7 @@ from typing import Union, List, Optional
 from copy import copy
 import numpy as np
 from scipy.sparse import issparse
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators.operator import Operator

--- a/qiskit_dynamics/type_utils.py
+++ b/qiskit_dynamics/type_utils.py
@@ -20,10 +20,9 @@ reshaping arrays, and handling qiskit types that wrap arrays.
 from typing import Union, List
 from collections.abc import Iterable
 import numpy as np
-from scipy.sparse import issparse, spmatrix
+from scipy.sparse import csr_matrix, issparse, spmatrix
 from scipy.sparse import kron as sparse_kron
 from scipy.sparse import identity as sparse_identity
-from scipy.sparse import csr_matrix
 
 from qiskit.quantum_info.operators import Operator
 from qiskit_dynamics.array import Array

--- a/qiskit_dynamics/type_utils.py
+++ b/qiskit_dynamics/type_utils.py
@@ -23,7 +23,7 @@ import numpy as np
 from scipy.sparse import issparse, spmatrix
 from scipy.sparse import kron as sparse_kron
 from scipy.sparse import identity as sparse_identity
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 
 from qiskit.quantum_info.operators import Operator
 from qiskit_dynamics.array import Array

--- a/test/dynamics/models/test_hamiltonian_model.py
+++ b/test/dynamics/models/test_hamiltonian_model.py
@@ -16,7 +16,7 @@
 import numpy as np
 
 from scipy.linalg import expm
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator

--- a/test/dynamics/models/test_operator_collections.py
+++ b/test/dynamics/models/test_operator_collections.py
@@ -16,7 +16,7 @@
 import numpy as np
 import numpy.random as rand
 from scipy.sparse import issparse
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator

--- a/test/dynamics/models/test_rotating_frame.py
+++ b/test/dynamics/models/test_rotating_frame.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 from qiskit_dynamics.models.rotating_frame import RotatingFrame
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.type_utils import to_BCOO, to_array

--- a/test/dynamics/test_type_utils.py
+++ b/test/dynamics/test_type_utils.py
@@ -15,7 +15,7 @@
 
 from collections.abc import Iterable
 import numpy as np
-from scipy.sparse.csr import csr_matrix
+from scipy.sparse import csr_matrix
 
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit_dynamics.array import Array


### PR DESCRIPTION
### Summary

Get rid of all the warnings
```
DeprecationWarning: Please use `csr_matrix` from the `scipy.sparse` namespace, the `scipy.sparse.csr` namespace is deprecated.
```


### Details and comments

As of early 2022, the `scipy.sparse.csr` module has been deprecated, and they advise that `csr_matrix` should be imported directly from `scipy.sparse`. This fix should be compatible with the current requirement `scipy>=1.4`.


