### PR TITLE
Remove property setter docstrings from the array folder

### DIFF
--- a/qiskit_dynamics/array/array.py
+++ b/qiskit_dynamics/array/array.py
@@ -92,7 +92,6 @@ class Array(NDArrayOperatorsMixin):
 
     @data.setter
     def data(self, value):
-        """Update the wrapped array data object."""
         self._data[:] = value
 
     @property
@@ -102,7 +101,6 @@ class Array(NDArrayOperatorsMixin):
 
     @backend.setter
     def backend(self, value: str):
-        """Set the backend of the wrapped array class."""
         Dispatch.validate_backend(value)
         self._data = asarray(self._data, backend=value)
         self._backend = value


### PR DESCRIPTION
### Summary

Remove property setter docstrings from the array folder.

### Details and comments

Property setter docstrings are not rendered by sphinx, or displayed with `help()`, and are therefore just one more thing to maintain.

Since I have already done a sweep through the array folder, this is a small change, but I plan to do this on all folders as I clean them. We can also double check that linting is still happy with this PR.
