### PR TITLE
Fix JAX version of t_span and t_eval merging functions

### DIFF
--- a/docs/userguide/how_to_use_jax.rst
+++ b/docs/userguide/how_to_use_jax.rst
@@ -142,8 +142,6 @@ before setting the signals, to ensure the simulation function remains pure.
         signals = [Signal(amp, carrier_freq=w)]
 
         # simulate and return results
-        # setting user_frame tells solve that states should be specified and returned in the frame
-        # of the drift
         results = solver.solve(
             t_span=[0, 3.],
             y0=np.array([0., 1.], dtype=complex),

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -135,12 +135,12 @@ def merge_t_args_jax(t_span, t_eval=None):
     if t_eval is None:
         return Array(t_span, backend="jax")
 
+    t_span = Array(t_span, backend="jax").data
+    t_eval = Array(t_eval, backend="jax").data
+
     # raise error if not one dimensional
     if t_eval.ndim > 1:
         raise ValueError("t_eval must be 1 dimensional.")
-
-    t_span = Array(t_span, backend="jax").data
-    t_eval = Array(t_eval, backend="jax").data
 
     out = jnp.append(jnp.append(t_span[0], t_eval), t_span[1])
 

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -124,20 +124,24 @@ def trim_t_results(
 
 def merge_t_args_jax(t_span, t_eval=None):
     """JAX-compilable version of merge_t_args. Rather than raise errors, sets return values to
-    jnp.nan to signal errors.
+    jnp.nan to signal errors. The merging strategy differs from merge_t_args: after appending
+    the endpoints of t_span to t_eval, it is checked whether the first two entries of the resulting
+    array are equal. If they are, the second entry is set to the average of the first and the third.
+    A similar procedure is done for the last two entries. This is essentially a hack to to avoid 
+    adjacent entries of the output having equal values, which causes buggy behaviour in jax_odeint.
     """
 
     if t_eval is None:
         return Array(t_span, backend="jax")
 
+    # raise error if not one dimensional
+    if t_eval.ndim > 1:
+        raise ValueError("t_eval must be 1 dimensional.")
+
     t_span = Array(t_span, backend="jax").data
     t_eval = Array(t_eval, backend="jax").data
 
     out = jnp.append(jnp.append(t_span[0], t_eval), t_span[1])
-
-    # raise error if not one dimensional
-    if t_eval.ndim > 1:
-        raise ValueError("t_eval must be 1 dimensional.")
 
     # output nan if t_eval point lies outside t_span
     t_min = jnp.min(t_span)
@@ -154,26 +158,54 @@ def merge_t_args_jax(t_span, t_eval=None):
     t_direction = jnp.sign(t_span[1] - t_span[0])
     out = cond(jnp.any(t_direction * diff < 0.0), lambda s: jnp.nan * s, lambda s: s, out)
 
+    # if out[0] == out[1], set out[1] == (out[2] + out[0])/2
+    out = cond(
+        out[0] == out[1],
+        lambda x: x.at[1].set((x[2] + x[0])/2),
+        lambda x: x,
+        out
+    )
+
+    # if out[-1] == out[-2], set out[-2] == (out[-3] + out[-1])/2
+    out = cond(
+        out[-1] == out[-2],
+        lambda x: x.at[-2].set((x[-3] + x[-1])/2),
+        lambda x: x,
+        out
+    )
+
     return Array(out)
 
 
 def trim_t_results_jax(results, t_eval):
-    """JAX-compilable version of trim_t_results. The cond call is necessary due to
-    a bug in odeint that only occurs if the first two time values are duplicates.
+    """JAX-compilable version of trim_t_results. Note the choice of which entry to remove in the
+    case of duplicate time entries is due to peculiarities in jax_odeint.
     """
 
     if t_eval is None:
         return results
 
+    # remove second entry if t_eval[0] == results.t[0], as this indicates this was a repeated time
     results.y = Array(
         cond(
-            results.t[0] == results.t[1],
-            lambda y: jnp.append(jnp.array([y[0]]), y[2:-1], axis=0),
-            lambda y: y[1:-1],
+            t_eval[0] == results.t[0],
+            lambda y: jnp.append(jnp.array([y[0]]), y[2:], axis=0),
+            lambda y: y[1:],
             Array(results.y).data,
         )
     )
-    results.t = Array(results.t[1:-1])
+
+    # remove second last entry if t_eval[-1] == results.t[-1], as this indicates a repeated time
+    results.y = Array(
+        cond(
+            t_eval[-1] == results.t[-1],
+            lambda y: jnp.append(y[:-2], jnp.array([y[-1]]), axis=0),
+            lambda y: y[:-1],
+            Array(results.y).data,
+        )
+    )
+
+    results.t = Array(t_eval)
     return results
 
 

--- a/test/dynamics/solvers/test_solver_utils.py
+++ b/test/dynamics/solvers/test_solver_utils.py
@@ -177,13 +177,13 @@ class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
         self.assertAllClose(times, np.array([0.0, 0.125, 0.25, 0.75, 0.875, 1.0]))
 
     def test_merge_t_args_with_overlap_backwards(self):
-        """Test merging with overlaps for backwards integration. Needs to override base version as the behaviour is
-        different.
+        """Test merging with overlaps for backwards integration. Needs to override base
+        version as the behaviour is different.
         """
         times = self.merge_t_args(
             t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75])
         )
-        self.assertAllClose(times, np.array([1.0, (1.0 - 0.25)/2, -0.25, -0.75, -1.0]))
+        self.assertAllClose(times, np.array([1.0, (1.0 - 0.25) / 2, -0.25, -0.75, -1.0]))
 
         times = self.merge_t_args(
             t_span=np.array([1.0, -1.0]), t_eval=np.array([-0.25, -0.75, -1.0])
@@ -193,7 +193,7 @@ class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
         times = self.merge_t_args(
             t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75, -1.0])
         )
-        self.assertAllClose(times, np.array([1.0, (1.0 - 0.25)/2, -0.25, -0.75, -0.875, -1.0]))
+        self.assertAllClose(times, np.array([1.0, (1.0 - 0.25) / 2, -0.25, -0.75, -0.875, -1.0]))
 
     def merge_t_args(self, t_span, t_eval=None):
         return merge_t_args_jax(t_span, t_eval)

--- a/test/dynamics/solvers/test_solver_utils.py
+++ b/test/dynamics/solvers/test_solver_utils.py
@@ -83,7 +83,7 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
         self.assertAllClose(times, -np.array([0.0, 0.25, 0.75, 1.0]))
 
     def test_merge_t_args_with_overlap(self):
-        """Test merging with with overlaps."""
+        """Test merging with overlaps."""
         times = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75]))
         self.assertAllClose(times, np.array([0.0, 0.0, 0.25, 0.75, 1.0]))
 
@@ -96,7 +96,7 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
         self.assertAllClose(times, np.array([0.0, 0.0, 0.25, 0.75, 1.0, 1.0]))
 
     def test_merge_t_args_with_overlap_backwards(self):
-        """Test merging with with overlaps for backwards integration."""
+        """Test merging with overlaps for backwards integration."""
         times = self.merge_t_args(
             t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75])
         )
@@ -160,6 +160,40 @@ class TestTimeArgsHandling(QiskitDynamicsTestCase):
 
 class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
     """Tests for merge_t_args_jax and trim_t_results_jax functions."""
+
+    def test_merge_t_args_with_overlap(self):
+        """Test merging with overlaps. Needs to override base version as the behaviour is
+        different.
+        """
+        times = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75]))
+        self.assertAllClose(times, np.array([0.0, 0.125, 0.25, 0.75, 1.0]))
+
+        times = self.merge_t_args(t_span=np.array([0.0, 1.0]), t_eval=np.array([0.25, 0.75, 1.0]))
+        self.assertAllClose(times, np.array([0.0, 0.25, 0.75, 0.875, 1.0]))
+
+        times = self.merge_t_args(
+            t_span=np.array([0.0, 1.0]), t_eval=np.array([0.0, 0.25, 0.75, 1.0])
+        )
+        self.assertAllClose(times, np.array([0.0, 0.125, 0.25, 0.75, 0.875, 1.0]))
+
+    def test_merge_t_args_with_overlap_backwards(self):
+        """Test merging with overlaps for backwards integration. Needs to override base version as the behaviour is
+        different.
+        """
+        times = self.merge_t_args(
+            t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75])
+        )
+        self.assertAllClose(times, np.array([1.0, (1.0 - 0.25)/2, -0.25, -0.75, -1.0]))
+
+        times = self.merge_t_args(
+            t_span=np.array([1.0, -1.0]), t_eval=np.array([-0.25, -0.75, -1.0])
+        )
+        self.assertAllClose(times, np.array([1.0, -0.25, -0.75, -0.875, -1.0]))
+
+        times = self.merge_t_args(
+            t_span=np.array([1.0, -1.0]), t_eval=np.array([1.0, -0.25, -0.75, -1.0])
+        )
+        self.assertAllClose(times, np.array([1.0, (1.0 - 0.25)/2, -0.25, -0.75, -0.875, -1.0]))
 
     def merge_t_args(self, t_span, t_eval=None):
         return merge_t_args_jax(t_span, t_eval)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #147 

Fixes the `merge_t_args_jax` and `trim_t_results_jax` functions. I think this is a final comprehensive solution to the problem that led to #147. 

### Details and comments

The bug stems from the following annoying technical issue that we've dealt with for a while:
- We've adopted scipy's `solve_ivp` time argument structure for specifying ODE problems in `solve_ode` and `solve_lmde`. `t_span` specifies the integration interval, and `t_eval` is an optional argument which tells the solver to only return the state at specific points in time (otherwise it will return it at whatever times the solvers stepped to).
- JAX's `odeint` function takes a single time argument, `ts`, which is essentially like `t_eval`, except the first and last times are interpreted as the whole integration interval. Hence, interfacing `odeint` into our `solve_ode`/`solve_lmde` functions requires translating the `t_span`/`t_eval` arguments into a single list of times to pass to `odeint`.
- One annoying peculiarity of `odeint`, which is what causes this bug, is that if the first or last entry of `ts` are repeated, the solution will have `nan` appearing in some entries (I'm forgetting which exactly). This is problematic for us because the endpoints of `t_span` are very commonly the endpoints of `t_eval`. Hence, merging `t_span` and `t_eval` into a single array by prepending/appending the entries of `t_span` onto `t_eval` will commonly result in repeated entries, causing this `nan` error to occur. (Note as well that we can't simply use `if` statements to check if these endpoints are equal and choose to append or not append them: this will violate the JAX requirement that the inputs/outputs to function are fixed-shape :D.)

I thought I had fixed this problem in #125: where the `nan` appear in the solution if duplicates are present is predictable, so `trim_t_results_jax` was written to avoid these values. However, #147 was created after discovering that this change made the calculation of gradients of solutions return `nan`. I think this is because the gradient computation of `odeint` will always utilize all intermediate computed solution values, so even though we were removing the `nan`'s, the gradient computation was still hitting them, which is something we couldn't avoid. This PR fixes this by changing the "merging strategy" of `merge_t_args` and `trim_t_results_jax`. Rather than just appending `t_span` to the ends of `t_eval`, we append them, then, conditional on if the endpoints are equal, modify the resulting combined array so that there are no duplicates, then correctly choosing the right entry when trimming the results. Importantly, this will not fundamentally impact the solver behaviour. 
