### PR TITLE
Pin tox version used in CI to <4.0.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
+        pip install -U virtualenv setuptools wheel 'tox<4'
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U tox setuptools virtualenv wheel
+        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel
       - name: Install and Run Tests with JAX
         run: tox -e jax
         if: runner.os != 'Windows'
@@ -54,7 +54,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U tox
+        run: python -m pip install -U 'tox<4'
       - name: Run lint
         run: tox -elint
   docs:
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install Deps
         run: |
-          python -m pip install -U tox
+          python -m pip install -U 'tox<4'
           sudo apt-get install graphviz pandoc
       - name: Build Docs
         run: tox -edocs


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Tox 4.0.0 has broken the github workflows. This PR is following @mtreinish 's PR to the qiskit meta package: https://github.com/Qiskit/qiskit/pull/1642

It is a temporary fix until things can be updated to be compatible with the new version of `tox`.