### PR TITLE
Update tox config for 4.x.x compatibility

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel 'tox<4'
+        pip install -U virtualenv setuptools wheel tox
         sudo apt-get install graphviz pandoc
     - name: Build and publish
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}
       - name: Install Deps
-        run: python -m pip install -U 'tox<4' setuptools virtualenv wheel
+        run: python -m pip install -U tox setuptools virtualenv wheel
       - name: Install and Run Tests with JAX
         run: tox -e jax
         if: runner.os != 'Windows'
@@ -54,7 +54,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.python-version }}-pip-
             ${{ runner.os }}-${{ matrix.python-version }}-
       - name: Install Deps
-        run: python -m pip install -U 'tox<4'
+        run: python -m pip install -U tox
       - name: Run lint
         run: tox -elint
   docs:
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-
       - name: Install Deps
         run: |
-          python -m pip install -U 'tox<4'
+          python -m pip install -U tox
           sudo apt-get install graphviz pandoc
       - name: Build Docs
         run: tox -edocs

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-minversion = 2.1
+minversion = 3.3.0
 envlist = py39,py38,py37,py310,lint
-skipsdist = True
+skipsdist = true
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
…d 4.x.x

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Follows @mtreinish 's https://github.com/Qiskit/qiskit-experiments/pull/990/files to fix compatibility of github workflows with tox's 4.0.0 update. 

### Details and comments

This removes the tox version pin of #158 , and instead updates `tox.ini` to be compatible with both 3.x.x and 4.x.x.
