### PR TITLE
Adding jax.Array to the JAX types in dispatch

### DIFF
--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -22,11 +22,15 @@ try:
     from jax.interpreters.ad import JVPTracer
     from jax.interpreters.partial_eval import JaxprTracer
 
-    # jax.Array was introduced in 4.0.0
-    if hasattr(jax, "Array"):
-        JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer, jax.Array)
-    else:
-        JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer)
+    JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer)
+
+    try:
+        # This class was introduced in 4.0.0
+        from jax import Array
+
+        JAX_TYPES += (Array,)
+    except ImportError:
+        pass
 
     try:
         # This class is not in older versions of Jax

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -22,7 +22,10 @@ try:
     from jax.interpreters.ad import JVPTracer
     from jax.interpreters.partial_eval import JaxprTracer
 
-    JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer)
+    if hasattr(jax, "Array"):
+        JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer, jax.Array)
+    else:
+        JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer)
 
     try:
         # This class is not in older versions of Jax

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -25,7 +25,7 @@ try:
     JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer)
 
     try:
-        # This class was introduced in 4.0.0
+        # This class was introduced in 0.4.0
         from jax import Array
 
         JAX_TYPES += (Array,)

--- a/qiskit_dynamics/dispatch/backends/jax.py
+++ b/qiskit_dynamics/dispatch/backends/jax.py
@@ -22,6 +22,7 @@ try:
     from jax.interpreters.ad import JVPTracer
     from jax.interpreters.partial_eval import JaxprTracer
 
+    # jax.Array was introduced in 4.0.0
     if hasattr(jax, "Array"):
         JAX_TYPES = (DeviceArray, Tracer, JaxprTracer, JVPTracer, jax.Array)
     else:

--- a/releasenotes/notes/jax-4-compatibility-8e3398e95f758dfe.yaml
+++ b/releasenotes/notes/jax-4-compatibility-8e3398e95f758dfe.yaml
@@ -1,4 +1,4 @@
 ---
 upgrade:
   - |
-    The ``jax.Array`` class has been added to the dispatcher for compatibility with JAX 4.
+    The ``jax.Array`` class has been added to the dispatcher for compatibility with JAX 0.4.0.

--- a/releasenotes/notes/jax-4-compatibility-8e3398e95f758dfe.yaml
+++ b/releasenotes/notes/jax-4-compatibility-8e3398e95f758dfe.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The ``jax.Array`` class has been added to the dispatcher for compatibility with JAX 4.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

JAX 0.4.0 was released today, introducing a new, unfortunately named array type called `Array`. This PR adds this to the list of recognized JAX array types in `dispatch`.

