### PR TITLE
Use opflow operators in dynamics

### DIFF
--- a/qiskit_dynamics/models/hamiltonian_model.py
+++ b/qiskit_dynamics/models/hamiltonian_model.py
@@ -22,6 +22,7 @@ from scipy.sparse.linalg import norm as spnorm
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
+from qiskit.opflow import OperatorBase
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.signals import Signal, SignalList
 from qiskit_dynamics.type_utils import to_numeric_matrix_type, to_array
@@ -64,10 +65,10 @@ class HamiltonianModel(GeneratorModel):
 
     def __init__(
         self,
-        static_operator: Optional[Array] = None,
-        operators: Optional[List[Operator]] = None,
+        static_operator: Optional[Union[Array, Operator, OperatorBase]] = None,
+        operators: Optional[List[Union[Array, Operator, OperatorBase]]] = None,
         signals: Optional[Union[SignalList, List[Signal]]] = None,
-        rotating_frame: Optional[Union[Operator, Array, RotatingFrame]] = None,
+        rotating_frame: Optional[Union[Operator, OperatorBase, Array, RotatingFrame]] = None,
         in_frame_basis: bool = False,
         evaluation_mode: str = "dense",
         validate: bool = True,

--- a/qiskit_dynamics/models/lindblad_model.py
+++ b/qiskit_dynamics/models/lindblad_model.py
@@ -21,6 +21,7 @@ from scipy.sparse import csr_matrix
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
+from qiskit.opflow import OperatorBase
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.type_utils import to_numeric_matrix_type
 from qiskit_dynamics.signals import Signal, SignalList
@@ -105,13 +106,15 @@ class LindbladModel(BaseGeneratorModel):
 
     def __init__(
         self,
-        static_hamiltonian: Optional[Union[Array, csr_matrix]] = None,
-        hamiltonian_operators: Optional[Union[Array, List[csr_matrix]]] = None,
+        static_hamiltonian: Optional[Union[Array, Operator, OperatorBase, csr_matrix]] = None,
+        hamiltonian_operators: Optional[
+            List[Union[Array, Operator, OperatorBase, csr_matrix]]
+        ] = None,
         hamiltonian_signals: Optional[Union[List[Signal], SignalList]] = None,
         static_dissipators: Optional[Union[Array, csr_matrix]] = None,
         dissipator_operators: Optional[Union[Array, List[csr_matrix]]] = None,
         dissipator_signals: Optional[Union[List[Signal], SignalList]] = None,
-        rotating_frame: Optional[Union[Operator, Array, RotatingFrame]] = None,
+        rotating_frame: Optional[Union[Operator, OperatorBase, Array, RotatingFrame]] = None,
         in_frame_basis: bool = False,
         evaluation_mode: Optional[str] = "dense",
         validate: bool = True,

--- a/qiskit_dynamics/models/rotating_frame.py
+++ b/qiskit_dynamics/models/rotating_frame.py
@@ -21,6 +21,7 @@ from scipy.sparse import issparse, csr_matrix
 
 from qiskit import QiskitError
 from qiskit.quantum_info.operators import Operator
+from qiskit.opflow import OperatorBase
 from qiskit.quantum_info.operators.predicates import is_hermitian_matrix
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.type_utils import to_array, to_BCOO, to_numeric_matrix_type
@@ -58,7 +59,10 @@ class RotatingFrame:
     """
 
     def __init__(
-        self, frame_operator: Union[Array, Operator], atol: float = 1e-10, rtol: float = 1e-10
+        self,
+        frame_operator: Union[Array, Operator, OperatorBase],
+        atol: float = 1e-10,
+        rtol: float = 1e-10,
     ):
         """Initialize with a frame operator.
 

--- a/qiskit_dynamics/type_utils.py
+++ b/qiskit_dynamics/type_utils.py
@@ -25,6 +25,7 @@ from scipy.sparse import kron as sparse_kron
 from scipy.sparse import identity as sparse_identity
 
 from qiskit.quantum_info.operators import Operator
+from qiskit.opflow import OperatorBase
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.dispatch import requires_backend
 
@@ -383,6 +384,9 @@ def to_array(op: Union[Operator, Array, List[Operator], List[Array], spmatrix], 
     if type(op).__name__ == "BCOO":
         return Array(op.todense())
 
+    if isinstance(op, OperatorBase):
+        return Array(op.to_matrix())
+
     if isinstance(op, Iterable) and not no_iter:
         op = Array([to_array(sub_op, no_iter=True) for sub_op in op])
     elif isinstance(op, Iterable) and no_iter:
@@ -452,7 +456,16 @@ def to_BCOO(op: Union[Operator, Array, List[Operator], List[Array], spmatrix, "B
 
 
 def to_numeric_matrix_type(
-    op: Union[Operator, Array, spmatrix, List[Operator], List[Array], List[spmatrix]]
+    op: Union[
+        Operator,
+        OperatorBase,
+        Array,
+        spmatrix,
+        List[Operator],
+        List[OperatorBase],
+        List[Array],
+        List[spmatrix],
+    ]
 ):
     """Given an operator, array, sparse matrix, or a list of operators, arrays, or sparse matrices,
     attempts to leave them in their original form, only converting the operator to an array,
@@ -482,6 +495,8 @@ def to_numeric_matrix_type(
         return op
     elif isinstance(op, Operator):
         return to_array(op)
+    elif isinstance(op, OperatorBase):
+        return op.to_matrix()
 
     elif isinstance(op, Iterable) and isinstance(op[0], spmatrix):
         return to_csr(op)

--- a/qiskit_dynamics/type_utils.py
+++ b/qiskit_dynamics/type_utils.py
@@ -355,11 +355,11 @@ def isinstance_qutip_qobj(obj):
 
 # pylint: disable=too-many-return-statements
 def to_array(op: Union[Operator, Array, List[Operator], List[Array], spmatrix], no_iter=False):
-    """Convert an operator or list of operators to an Array.
+    """Convert an operator, operatorBase, or list of either to an Array.
     Args:
-        op: Either an Operator to be converted to an array, a list of Operators
-            to be converted to a 3d array, or an array (which simply gets
-            returned)
+        op: Either a single `Operator` or `OperatorBase` to be converted to an array
+            or a list of either to be converted to a 3d array
+            or an array (which simply gets returned)
         no_iter (Bool): Boolean determining whether to recursively unroll `Iterables`.
             If recurring, this should be True to avoid making each element of the
             input array into a separate Array.
@@ -467,7 +467,7 @@ def to_numeric_matrix_type(
         List[spmatrix],
     ]
 ):
-    """Given an operator, array, sparse matrix, or a list of operators, arrays, or sparse matrices,
+    """Given an operator, array, sparse matrix or a list of operators, arrays or sparse matrices,
     attempts to leave them in their original form, only converting the operator to an array,
     and converting lists as necessary. Summarized below:
     - operator is converted to array
@@ -496,7 +496,7 @@ def to_numeric_matrix_type(
     elif isinstance(op, Operator):
         return to_array(op)
     elif isinstance(op, OperatorBase):
-        return op.to_matrix()
+        return to_array(op)
 
     elif isinstance(op, Iterable) and isinstance(op[0], spmatrix):
         return to_csr(op)

--- a/releasenotes/notes/add-opflow-operator-support-65ffc97e07c344ee.yaml
+++ b/releasenotes/notes/add-opflow-operator-support-65ffc97e07c344ee.yaml
@@ -11,6 +11,7 @@ features:
         operators = [X,Y]
         hamiltonian_solver = dynamics.Solver(
             static_hamiltonian = drift,
-            hamiltonian_operators = operators
+            hamiltonian_operators = operators,
+            rotating_frame = drift
         )
       

--- a/releasenotes/notes/add-opflow-operator-support-65ffc97e07c344ee.yaml
+++ b/releasenotes/notes/add-opflow-operator-support-65ffc97e07c344ee.yaml
@@ -1,0 +1,16 @@
+features:
+  - |
+    ``qiskit.opflow`` Operators can now be used to specify operators for the ``HamiltonianModel``
+    and the ``RotatingFrame``
+    Example::
+
+        from qiskit_dynamics.solvers import Solver
+        from qiskit.opflow import X, Y, Z
+
+        drift = Z/2
+        operators = [X,Y]
+        hamiltonian_solver = dynamics.Solver(
+            static_hamiltonian = drift,
+            hamiltonian_operators = operators
+        )
+      

--- a/test/dynamics/test_type_utils.py
+++ b/test/dynamics/test_type_utils.py
@@ -18,6 +18,7 @@ import numpy as np
 from scipy.sparse import csr_matrix
 
 from qiskit.quantum_info.operators.operator import Operator
+from qiskit.opflow import X, Y, Z
 from qiskit_dynamics.array import Array
 from qiskit_dynamics.type_utils import (
     convert_state,
@@ -524,10 +525,12 @@ class Test_to_numeric_matrix_type(QiskitDynamicsTestCase):
         normal_array = Array(np.array(list_of_ops))
         list_of_arrays = [Array(op) for op in list_of_ops]
         op_arr = [Operator.from_label(s) for s in "XYZ"]
+        opflow_arr = [X, Y, Z]
         sparse_matrices = [csr_matrix(op) for op in list_of_ops]
         self.assertAllClose(to_numeric_matrix_type(list_of_ops), normal_array)
         self.assertAllClose(to_numeric_matrix_type(list_of_arrays), normal_array)
         self.assertAllClose(to_numeric_matrix_type(op_arr), list_of_arrays)
+        self.assertAllClose(to_numeric_matrix_type(opflow_arr), list_of_arrays)
         for i in range(3):
             self.assertAllCloseSparse(
                 to_numeric_matrix_type(sparse_matrices)[i], sparse_matrices[i]


### PR DESCRIPTION
### Summary

Add support and type hints, so that qiskit.opflow operators inheriting from qiskit.opflow.OperatorBase can be used to construct a HamiltonianModel and a RotatingFrame.

### Details and comments

It kind of gets messy with the type hints, not sure what to do about that.

Needs the "New Feature" Label, not sure if I can do this myself.
