### PR TITLE
Fixing tests failing due to numpy eigh sign convention changes

### DIFF
--- a/test/dynamics/models/test_generator_model.py
+++ b/test/dynamics/models/test_generator_model.py
@@ -762,8 +762,7 @@ class Testtransfer_operator_functions(QiskitDynamicsTestCase):
         new_frame = rng.uniform(low=-b, high=b, size=(dim, dim)) + 1j * rng.uniform(
             low=-b, high=b, size=(dim, dim)
         )
-        new_frame = new_frame - new_frame.conj().transpose()
-        new_frame = RotatingFrame(new_frame)
+        new_frame = RotatingFrame(new_frame - new_frame.conj().transpose())
 
         out_static = transfer_static_operator_between_frames(
             Array(static_operator), new_frame=new_frame, old_frame=old_frame

--- a/test/dynamics/models/test_generator_model.py
+++ b/test/dynamics/models/test_generator_model.py
@@ -756,8 +756,7 @@ class Testtransfer_operator_functions(QiskitDynamicsTestCase):
         old_frame = rng.uniform(low=-b, high=b, size=(dim, dim)) + 1j * rng.uniform(
             low=-b, high=b, size=(dim, dim)
         )
-        old_frame = old_frame - old_frame.conj().transpose()
-        old_frame = RotatingFrame(old_frame)
+        old_frame = RotatingFrame(old_frame - old_frame.conj().transpose())
 
         new_frame = rng.uniform(low=-b, high=b, size=(dim, dim)) + 1j * rng.uniform(
             low=-b, high=b, size=(dim, dim)

--- a/test/dynamics/models/test_generator_model.py
+++ b/test/dynamics/models/test_generator_model.py
@@ -2,13 +2,12 @@
 #
 # (C) Copyright IBM 2020.
 #
-# This code is licensed under the Apache License, Version 2.0. You may
-# obtain a copy of this license in the LICENSE.txt file in the root directory
-# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
 #
-# Any modifications or derivative works of this code must retain this
-# copyright notice, and modified files need to carry a notice indicating
-# that they have been altered from the originals.
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
 # pylint: disable=invalid-name
 
 """Tests for generator_models.py. """
@@ -758,28 +757,32 @@ class Testtransfer_operator_functions(QiskitDynamicsTestCase):
             low=-b, high=b, size=(dim, dim)
         )
         old_frame = old_frame - old_frame.conj().transpose()
+        old_frame = RotatingFrame(old_frame)
+
         new_frame = rng.uniform(low=-b, high=b, size=(dim, dim)) + 1j * rng.uniform(
             low=-b, high=b, size=(dim, dim)
         )
         new_frame = new_frame - new_frame.conj().transpose()
+        new_frame = RotatingFrame(new_frame)
 
         out_static = transfer_static_operator_between_frames(
-            Array(static_operator), new_frame=Array(new_frame), old_frame=Array(old_frame)
+            Array(static_operator), new_frame=new_frame, old_frame=old_frame
         )
         out_operators = transfer_operators_between_frames(
-            Array(operators), new_frame=Array(new_frame), old_frame=Array(old_frame)
+            Array(operators), new_frame=new_frame, old_frame=old_frame
         )
 
         self.assertTrue(isinstance(out_static, (np.ndarray, Array)))
         self.assertTrue(isinstance(out_operators, (np.ndarray, Array)))
 
-        _, U = wrap(np.linalg.eigh)(1j * old_frame)
-        _, V = wrap(np.linalg.eigh)(1j * new_frame)
-        Uadj = U.conj().transpose()
-        Vadj = V.conj().transpose()
-
-        expected_static = Vadj @ ((U @ static_operator @ Uadj + old_frame) - new_frame) @ V
-        expected_operators = Vadj @ (U @ operators @ Uadj) @ V
+        expected_static = new_frame.operator_into_frame_basis(
+            (old_frame.operator_out_of_frame_basis(static_operator) + old_frame.frame_operator)
+            - new_frame.frame_operator
+        )
+        expected_operators = [
+            new_frame.operator_into_frame_basis(old_frame.operator_out_of_frame_basis(op))
+            for op in operators
+        ]
 
         self.assertAllClose(out_static, expected_static)
         self.assertAllClose(out_operators, expected_operators)

--- a/test/dynamics/solvers/test_lanczos.py
+++ b/test/dynamics/solvers/test_lanczos.py
@@ -2,13 +2,12 @@
 #
 # (C) Copyright IBM 2022.
 #
-# This code is licensed under the Apache License, Version 2.0. You may
-# obtain a copy of this license in the LICENSE.txt file in the root directory
-# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+# This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license
+# in the LICENSE.txt file in the root directory of this source tree or at
+# http://www.apache.org/licenses/LICENSE-2.0.
 #
-# Any modifications or derivative works of this code must retain this
-# copyright notice, and modified files need to carry a notice indicating
-# that they have been altered from the originals.
+# Any modifications or derivative works of this code must retain this copyright notice, and modified
+# files need to carry a notice indicating that they have been altered from the originals.
 # pylint: disable=invalid-name
 
 """
@@ -64,7 +63,9 @@ class TestLanczos(QiskitDynamicsTestCase):
         eigen_vectors_l = q_basis @ eigen_vectors_t
         eigen_values_np, eigen_vectors_np = np.linalg.eigh(self.rand_op)
 
-        self.assertAllClose(eigen_vectors_np[:, 0], eigen_vectors_l[:, 0])
+        # test overlap is 1.
+        overlap = np.abs(np.sum(eigen_vectors_np[:, 0].conj() * eigen_vectors_l[:, 0]))
+        self.assertAllClose(overlap, 1.0)
         self.assertAllClose(eigen_values_np[0], eigen_values_l[0])
 
     def test_expm(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #171.

As described in #171, a numpy update cause signs of eigenvectors output by `eigh` to change in some tests. While the output is mathematically correct in both cases, our tests were dependent on the exact value of the entries of the eigenvectors, leading to errors.

Both tests have been modified to be independent of the sign of the eigenvectors output of `eigh`, avoiding this issue.
