### PR TITLE
Adjustments to some parameter handling in DynamicsBackend

### DIFF
--- a/qiskit_dynamics/backend/backend_utils.py
+++ b/qiskit_dynamics/backend/backend_utils.py
@@ -29,7 +29,7 @@ from qiskit_dynamics.type_utils import to_array
 
 
 def _get_dressed_state_decomposition(
-    operator: np.ndarray, rtol=1e-8, atol=1e-8
+    operator: np.ndarray, rtol=1e-8, atol=1e-5
 ) -> Union[Dict[str, np.ndarray], List[float], Dict[str, float]]:
     """Get the eigenvalues and eigenvectors of a nearly-diagonal hermitian operator, sorted
     according to overlap with the elementary basis.

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -28,7 +28,8 @@ from scipy.integrate._ivp.ivp import OdeResult  # pylint: disable=unused-import
 from qiskit import pulse
 from qiskit.qobj.utils import MeasLevel, MeasReturnType
 from qiskit.qobj.common import QobjHeader
-from qiskit.transpiler import Target
+from qiskit.transpiler import Target, InstructionProperties
+from qiskit.circuit.library import Measure
 from qiskit.pulse import Schedule, ScheduleBlock
 from qiskit.pulse.transforms.canonicalization import block_to_schedule
 from qiskit.providers.options import Options
@@ -148,15 +149,20 @@ class DynamicsBackend(BackendV2):
             target = copy.copy(target)
 
         # add default simulator measure instructions
-        instruction_schedule_map = target.instruction_schedule_map()
+        measure_properties = {}
         for qubit in self.options.subsystem_labels:
-            if not instruction_schedule_map.has(instruction="measure", qubits=qubit):
+            instruction_schedule_map = target.instruction_schedule_map()
+            if not instruction_schedule_map.has(instruction='measure', qubits=qubit):
                 with pulse.build() as meas_sched:
                     pulse.acquire(
                         duration=1, qubit_or_channel=qubit, register=pulse.MemorySlot(qubit)
                     )
+            
+            measure_properties[(qubit,)] = InstructionProperties(calibration=meas_sched)
+        
+        target.add_instruction(Measure(), measure_properties)
 
-            instruction_schedule_map.add(instruction="measure", qubits=qubit, schedule=meas_sched)
+        target.dt = solver._dt
 
         self._target = target
 
@@ -343,6 +349,7 @@ class DynamicsBackend(BackendV2):
 
         # compute results for each experiment
         experiment_names = [schedule.name for schedule in schedules]
+        experiment_metadatas = [schedule.metadata for schedule in schedules]
         rng = np.random.default_rng(self.options.seed_simulator)
         experiment_results = []
         for (
@@ -351,13 +358,22 @@ class DynamicsBackend(BackendV2):
             measurement_subsystems,
             memory_slot_indices,
             num_memory_slots,
+            experiment_metadata
         ) in zip(
             experiment_names,
             solver_results,
             measurement_subsystems_list,
             memory_slot_indices_list,
             num_memory_slots_list,
+            experiment_metadatas
         ):
+            #***********************************************************************************************
+            # this is a bit of a hack for 0-length schedules (I guess checking for spam error?)
+            # we could change experiment_result_function to take y[-1] and t[-1], not sure why
+            # they don't currently
+            if solver_result.t[-1] == 0:
+                solver_result.y[-1] = solver_result.y[0]
+
             experiment_results.append(
                 self.options.experiment_result_function(
                     experiment_name,
@@ -367,6 +383,7 @@ class DynamicsBackend(BackendV2):
                     num_memory_slots,
                     self,
                     seed=rng.integers(low=0, high=9223372036854775807),
+                    metadata=experiment_metadata
                 )
             )
 
@@ -402,6 +419,7 @@ def default_experiment_result_function(
     num_memory_slots: Union[None, int],
     backend: DynamicsBackend,
     seed: Optional[int] = None,
+    metadata: any = None
 ) -> ExperimentResult:
     """Default routine for generating ExperimentResult object.
 
@@ -479,7 +497,7 @@ def default_experiment_result_function(
             data=exp_data,
             meas_level=MeasLevel.CLASSIFIED,
             seed=seed,
-            header=QobjHeader(name=experiment_name),
+            header=QobjHeader(name=experiment_name, metadata=metadata),
         )
     elif backend.options.meas_level == MeasLevel.KERNELED:
         iq_centers = backend.options.iq_centers
@@ -515,7 +533,7 @@ def default_experiment_result_function(
             data=exp_data,
             meas_level=MeasLevel.KERNELED,
             seed=seed,
-            header=QobjHeader(name=experiment_name),
+            header=QobjHeader(name=experiment_name, metadata=metadata),
         )
 
     else:

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -152,14 +152,14 @@ class DynamicsBackend(BackendV2):
         measure_properties = {}
         for qubit in self.options.subsystem_labels:
             instruction_schedule_map = target.instruction_schedule_map()
-            if not instruction_schedule_map.has(instruction='measure', qubits=qubit):
+            if not instruction_schedule_map.has(instruction="measure", qubits=qubit):
                 with pulse.build() as meas_sched:
                     pulse.acquire(
                         duration=1, qubit_or_channel=qubit, register=pulse.MemorySlot(qubit)
                     )
-            
+
             measure_properties[(qubit,)] = InstructionProperties(calibration=meas_sched)
-        
+
         target.add_instruction(Measure(), measure_properties)
 
         target.dt = solver._dt
@@ -358,14 +358,14 @@ class DynamicsBackend(BackendV2):
             measurement_subsystems,
             memory_slot_indices,
             num_memory_slots,
-            experiment_metadata
+            experiment_metadata,
         ) in zip(
             experiment_names,
             solver_results,
             measurement_subsystems_list,
             memory_slot_indices_list,
             num_memory_slots_list,
-            experiment_metadatas
+            experiment_metadatas,
         ):
             experiment_results.append(
                 self.options.experiment_result_function(
@@ -376,7 +376,7 @@ class DynamicsBackend(BackendV2):
                     num_memory_slots,
                     self,
                     seed=rng.integers(low=0, high=9223372036854775807),
-                    metadata=experiment_metadata
+                    metadata=experiment_metadata,
                 )
             )
 
@@ -412,7 +412,7 @@ def default_experiment_result_function(
     num_memory_slots: Union[None, int],
     backend: DynamicsBackend,
     seed: Optional[int] = None,
-    metadata: Optional[Dict] = None
+    metadata: Optional[Dict] = None,
 ) -> ExperimentResult:
     """Default routine for generating ExperimentResult object.
 
@@ -431,7 +431,7 @@ def default_experiment_result_function(
         backend: The backend instance that ran the simulation. Various options and properties
             are utilized.
         seed: Seed for any random number generation involved (e.g. when computing outcome samples).
-        metadata: Metadata to add to the header of the 
+        metadata: Metadata to add to the header of the
             :class:`~qiskit.result.models.ExperimentResult` object.
 
     Returns:

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -367,13 +367,6 @@ class DynamicsBackend(BackendV2):
             num_memory_slots_list,
             experiment_metadatas
         ):
-            #***********************************************************************************************
-            # this is a bit of a hack for 0-length schedules (I guess checking for spam error?)
-            # we could change experiment_result_function to take y[-1] and t[-1], not sure why
-            # they don't currently
-            if solver_result.t[-1] == 0:
-                solver_result.y[-1] = solver_result.y[0]
-
             experiment_results.append(
                 self.options.experiment_result_function(
                     experiment_name,

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -20,7 +20,7 @@ Pulse-enabled simulator backend.
 import datetime
 import uuid
 
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict
 import copy
 import numpy as np
 from scipy.integrate._ivp.ivp import OdeResult  # pylint: disable=unused-import
@@ -419,7 +419,7 @@ def default_experiment_result_function(
     num_memory_slots: Union[None, int],
     backend: DynamicsBackend,
     seed: Optional[int] = None,
-    metadata: any = None
+    metadata: Optional[Dict] = None
 ) -> ExperimentResult:
     """Default routine for generating ExperimentResult object.
 

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -438,9 +438,11 @@ def default_experiment_result_function(
         backend: The backend instance that ran the simulation. Various options and properties
             are utilized.
         seed: Seed for any random number generation involved (e.g. when computing outcome samples).
+        metadata: Metadata to add to the header of the 
+            :class:`~qiskit.result.models.ExperimentResult` object.
 
     Returns:
-        ExperimentResult object containing results.
+        :class:`~qiskit.result.models.ExperimentResult` object containing results.
 
     Raises:
         QiskitError: If a specified option is unsupported.

--- a/qiskit_dynamics/backend/dynamics_job.py
+++ b/qiskit_dynamics/backend/dynamics_job.py
@@ -77,7 +77,7 @@ class DynamicsJob(Job):
             return JobStatus.INITIALIZING
 
         return JobStatus.DONE
-    
+
     def time_per_step(self) -> Dict:
         """Return the date and time information on each step of the job processing.
 

--- a/qiskit_dynamics/backend/dynamics_job.py
+++ b/qiskit_dynamics/backend/dynamics_job.py
@@ -41,6 +41,7 @@ class DynamicsJob(Job):
         self._fn = fn
         self._fn_kwargs = fn_kwargs
         self._result = None
+        self._time_per_step = {"CREATED": datetime.now()}
 
     def submit(self):
         """Run the simulation.
@@ -51,6 +52,7 @@ class DynamicsJob(Job):
         if self._result is not None:
             raise JobError("Dynamics job has already been submitted.")
         self._result = self._fn(job_id=self.job_id(), **self._fn_kwargs)
+        self._time_per_step["COMPLETED"] = datetime.now()
 
     def result(self):
         """Get job result.
@@ -76,7 +78,10 @@ class DynamicsJob(Job):
 
         return JobStatus.DONE
     
-    def time_per_step(self):
-        # this is a hack *********************************************************************************
-        # Need to put actual handling in there
-        return {"COMPLETED": datetime.now()}
+    def time_per_step(self) -> Dict:
+        """Return the date and time information on each step of the job processing.
+
+        Returns:
+            Dict for time of creation and time of completion of job.
+        """
+        return self._time_per_step

--- a/qiskit_dynamics/backend/dynamics_job.py
+++ b/qiskit_dynamics/backend/dynamics_job.py
@@ -13,6 +13,7 @@
 """This module implements the job class used for DynamicsBackend objects."""
 
 from typing import Callable, Dict
+from datetime import datetime
 
 from qiskit.providers.backend import Backend
 from qiskit.providers import JobV1 as Job
@@ -55,7 +56,7 @@ class DynamicsJob(Job):
         """Get job result.
 
         Returns:
-            qiskit.Result: Result object
+            qiskit.Result: Result object.
 
         Raises:
             JobError: If job has not been submitted.
@@ -74,3 +75,8 @@ class DynamicsJob(Job):
             return JobStatus.INITIALIZING
 
         return JobStatus.DONE
+    
+    def time_per_step(self):
+        # this is a hack *********************************************************************************
+        # Need to put actual handling in there
+        return {"COMPLETED": datetime.now()}

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -191,18 +191,18 @@ def trim_t_results_jax(
     peculiarities in :func:`jax_odeint`.
 
     Args:
-        results: Result object, assumed to contain solution at time points from the output of 
+        results: Result object, assumed to contain solution at time points from the output of
             ``merge_t_args_jax(t_span, t_eval)``.
         t_eval: Time points to include in returned results.
 
     Returns:
-        OdeResult: Results with only times/solutions in ``t_eval``. If ``t_eval`` is ``None``, 
-            returns solver default output, with an additional correction for the possibility of 
+        OdeResult: Results with only times/solutions in ``t_eval``. If ``t_eval`` is ``None``,
+            returns solver default output, with an additional correction for the possibility of
             ``t_span == [a, a]``.
     """
 
     if t_eval is not None:
-        # remove second entry if t_eval[0] == results.t[0], as this indicates this was a repeated time
+        # remove second entry if t_eval[0] == results.t[0], as this indicates a repeated time
         results.y = Array(
             cond(
                 t_eval[0] == results.t[0],
@@ -230,10 +230,9 @@ def trim_t_results_jax(
             results.t[0] == results.t[-1],
             lambda y: y.at[-1].set(y[0]),
             lambda y: y,
-            Array(results.y).data
+            Array(results.y).data,
         )
     )
-
 
     return results
 

--- a/qiskit_dynamics/solvers/solver_utils.py
+++ b/qiskit_dynamics/solvers/solver_utils.py
@@ -48,12 +48,11 @@ def merge_t_args(
 ) -> Union[List, Tuple, Array]:
     """Merge ``t_span`` and ``t_eval`` into a single array.
 
-    Validition is similar to scipy ``solve_ivp``:
-    ``t_eval`` must be contained in ``t_span``, and be increasing if
-    ``t_span[1] > t_span[0]`` or decreasing if ``t_span[1] < t_span[0]``.
+    Validition is similar to scipy ``solve_ivp``: ``t_eval`` must be contained in ``t_span``, and be
+    increasing if ``t_span[1] > t_span[0]`` or decreasing if ``t_span[1] < t_span[0]``.
 
-    Note: this is done explicitly with ``numpy``, and hence this is
-    not differentiable or compilable using jax.
+    Note: this is done explicitly with ``numpy``, and hence this is not differentiable or compilable
+    using jax.
 
     If ``t_eval is None`` returns ``t_span`` with no modification.
 
@@ -192,39 +191,50 @@ def trim_t_results_jax(
     peculiarities in :func:`jax_odeint`.
 
     Args:
-        results: Result object, assumed to contain solution at time points
-                 from the output of ``merge_t_args_jax(t_span, t_eval)``.
+        results: Result object, assumed to contain solution at time points from the output of 
+            ``merge_t_args_jax(t_span, t_eval)``.
         t_eval: Time points to include in returned results.
 
     Returns:
-        OdeResult: Results with only times/solutions in ``t_eval``. If ``t_eval``
-                   is ``None``, does nothing, returning solver default output.
+        OdeResult: Results with only times/solutions in ``t_eval``. If ``t_eval`` is ``None``, 
+            returns solver default output, with an additional correction for the possibility of 
+            ``t_span == [a, a]``.
     """
 
-    if t_eval is None:
-        return results
+    if t_eval is not None:
+        # remove second entry if t_eval[0] == results.t[0], as this indicates this was a repeated time
+        results.y = Array(
+            cond(
+                t_eval[0] == results.t[0],
+                lambda y: jnp.append(jnp.array([y[0]]), y[2:], axis=0),
+                lambda y: y[1:],
+                Array(results.y).data,
+            )
+        )
 
-    # remove second entry if t_eval[0] == results.t[0], as this indicates this was a repeated time
+        # remove second last entry if t_eval[-1] == results.t[-1], as this indicates a repeated time
+        results.y = Array(
+            cond(
+                t_eval[-1] == results.t[-1],
+                lambda y: jnp.append(y[:-2], jnp.array([y[-1]]), axis=0),
+                lambda y: y[:-1],
+                Array(results.y).data,
+            )
+        )
+
+        results.t = Array(t_eval)
+
+    # this handles the odd case that t_span == [a, a]
     results.y = Array(
         cond(
-            t_eval[0] == results.t[0],
-            lambda y: jnp.append(jnp.array([y[0]]), y[2:], axis=0),
-            lambda y: y[1:],
-            Array(results.y).data,
+            results.t[0] == results.t[-1],
+            lambda y: y.at[-1].set(y[0]),
+            lambda y: y,
+            Array(results.y).data
         )
     )
 
-    # remove second last entry if t_eval[-1] == results.t[-1], as this indicates a repeated time
-    results.y = Array(
-        cond(
-            t_eval[-1] == results.t[-1],
-            lambda y: jnp.append(y[:-2], jnp.array([y[-1]]), axis=0),
-            lambda y: y[:-1],
-            Array(results.y).data,
-        )
-    )
 
-    results.t = Array(t_eval)
     return results
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,3 +12,4 @@ sphinxcontrib-bibtex
 qutip
 ddt~=1.4.2
 matplotlib>=3.3.0
+qiskit-experiments

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -19,7 +19,8 @@ import numpy as np
 from scipy.integrate._ivp.ivp import OdeResult
 
 from qiskit import QiskitError, pulse, QuantumCircuit
-from qiskit.transpiler import Target
+from qiskit.circuit.library import XGate
+from qiskit.transpiler import Target, InstructionProperties
 from qiskit.quantum_info import Statevector, DensityMatrix
 from qiskit.result.models import ExperimentResult, ExperimentResultData
 
@@ -310,8 +311,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
             pulse.play(pulse.Waveform([1.0] * 100), pulse.DriveChannel(0))
 
         target = Target()
-        inst_sched_map = target.instruction_schedule_map()
-        inst_sched_map.add("x", qubits=0, schedule=x_sched0)
+        target.add_instruction(XGate(), {(0,): InstructionProperties(calibration=x_sched0)})
 
         backend = DynamicsBackend(solver=self.simple_solver, target=target)
 

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -455,6 +455,27 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
             experiment_result_function=exp_result_function,
         ).result()
         self.assertDictEqual(result.get_counts(), {"3": 1})
+    
+    def test_metadata_transfer(self):
+        """Test that circuit metadata is correctly stored in the result object."""
+
+        solver = Solver(static_hamiltonian=np.diag([-1.0, 0.0, 1.0]), dt=0.1)
+        qutrit_backend = DynamicsBackend(
+            solver=solver, max_outcome_level=None, initial_state=Statevector([0.0, 0.0, 1.0])
+        )
+
+        circ0 = QuantumCircuit(1, 1, metadata={"key0": "value0"})
+        circ0.measure([0], [0])
+        circ1 = QuantumCircuit(1, 1, metadata={"key1": "value1"})
+        circ1.measure([0], [0])
+
+        res = qutrit_backend.run([circ0, circ1]).result()
+
+        self.assertDictEqual(res.get_counts(0), {"2": 1024})
+        self.assertDictEqual(res.results[0].header.metadata, {"key0": "value0"})
+        self.assertDictEqual(res.get_counts(1), {"2": 1024})
+        self.assertDictEqual(res.results[1].header.metadata, {"key1": "value1"})
+
 
 
 class Test_default_experiment_result_function(QiskitDynamicsTestCase):

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -455,7 +455,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
             experiment_result_function=exp_result_function,
         ).result()
         self.assertDictEqual(result.get_counts(), {"3": 1})
-    
+
     def test_metadata_transfer(self):
         """Test that circuit metadata is correctly stored in the result object."""
 
@@ -475,7 +475,6 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
         self.assertDictEqual(res.results[0].header.metadata, {"key0": "value0"})
         self.assertDictEqual(res.get_counts(1), {"2": 1024})
         self.assertDictEqual(res.results[1].header.metadata, {"key1": "value1"})
-
 
 
 class Test_default_experiment_result_function(QiskitDynamicsTestCase):

--- a/test/dynamics/backend/test_dynamics_job.py
+++ b/test/dynamics/backend/test_dynamics_job.py
@@ -56,3 +56,14 @@ class TestDynamicsJob(QiskitDynamicsTestCase):
     def test_metadata(self):
         """Test metadata storage."""
         self.assertTrue(self.simple_job.metadata == {"other_kwarg": "for testing"})
+    
+    def test_time_per_step(self):
+        """Test correct handling of time_per_step."""
+
+        self.assertTrue(list(self.simple_job.time_per_step().keys()) == ["CREATED"])
+
+        self.simple_job.submit()
+        keys = self.simple_job.time_per_step().keys()
+        self.assertTrue(len(keys) == 2)
+        self.assertTrue("CREATED" in keys)
+        self.assertTrue("COMPLETED" in keys)

--- a/test/dynamics/backend/test_dynamics_job.py
+++ b/test/dynamics/backend/test_dynamics_job.py
@@ -56,7 +56,7 @@ class TestDynamicsJob(QiskitDynamicsTestCase):
     def test_metadata(self):
         """Test metadata storage."""
         self.assertTrue(self.simple_job.metadata == {"other_kwarg": "for testing"})
-    
+
     def test_time_per_step(self):
         """Test correct handling of time_per_step."""
 

--- a/test/dynamics/backend/test_qiskit_experiments.py
+++ b/test/dynamics/backend/test_qiskit_experiments.py
@@ -63,7 +63,6 @@ class TestExperimentsIntegration(QiskitDynamicsTestCase, TestJaxBase):
     def test_RoughFrequencyCal_calibration(self):
         """Test RoughFrequencyCal outputs a sensible answer."""
 
-        # cals = Calibrations.from_backend(self.simple_backend)
         cals = Calibrations()
 
         dur = Parameter("dur")

--- a/test/dynamics/backend/test_qiskit_experiments.py
+++ b/test/dynamics/backend/test_qiskit_experiments.py
@@ -66,14 +66,12 @@ class TestExperimentsIntegration(QiskitDynamicsTestCase, TestJaxBase):
         cals = Calibrations()
 
         dur = Parameter("dur")
-        amp = Parameter("amp")
         sigma = Parameter("sigma")
-        beta = Parameter("beta")
         drive = pulse.DriveChannel(Parameter("ch0"))
 
         # Define and add template schedules.
         with pulse.build(name="x") as x:
-            pulse.play(pulse.Drag(dur, amp, sigma, beta), drive)
+            pulse.play(pulse.Drag(dur, Parameter("amp"), sigma, Parameter("beta")), drive)
 
         with pulse.build(name="sx") as sx:
             pulse.play(pulse.Drag(dur, Parameter("amp"), sigma, Parameter("beta")), drive)

--- a/test/dynamics/backend/test_qiskit_experiments.py
+++ b/test/dynamics/backend/test_qiskit_experiments.py
@@ -1,0 +1,101 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=invalid-name
+
+"""
+Integration tests that ensure this module interacts properly with qiskit-experiments.
+"""
+
+import numpy as np
+
+from qiskit import pulse
+from qiskit.circuit import Parameter
+from qiskit.circuit.library import XGate, SXGate
+from qiskit.transpiler import Target
+from qiskit.providers.backend import QubitProperties
+from qiskit_experiments.calibration_management.calibrations import Calibrations
+from qiskit_experiments.library.calibration.rough_frequency import RoughFrequencyCal
+
+from qiskit_dynamics import Solver, DynamicsBackend
+from ..common import QiskitDynamicsTestCase, TestJaxBase
+
+
+class TestExperimentsIntegration(QiskitDynamicsTestCase, TestJaxBase):
+    """Test class for verifying correct integration with qiskit-experiments. Set to use JAX for
+    speed.
+    """
+
+    def setUp(self):
+        """Build simple simulator for multiple tests."""
+
+        # build the solver
+        solver = Solver(
+            static_hamiltonian=2 * np.pi * 5.0 * np.array([[-1.0, 0.0], [0.0, 1.0]]) / 2,
+            hamiltonian_operators=[2 * np.pi * np.array([[0.0, 1.0], [1.0, 0.0]]) / 2],
+            rotating_frame=2 * np.pi * 5.0 * np.array([[-1.0, 0.0], [0.0, 1.0]]) / 2,
+            hamiltonian_channels=["d0"],
+            channel_carrier_freqs={"d0": 5.0},
+            dt=1.0 / 4.5,
+        )
+
+        # build target gate definitions
+        target = Target()
+        target.qubit_properties = [QubitProperties(frequency=5.0)]
+
+        target.add_instruction(XGate())
+        target.add_instruction(SXGate())
+
+        self.simple_backend = DynamicsBackend(
+            solver=solver,
+            target=target,
+            solver_options={"method": "jax_odeint", "atol": 1e-6, "rtol": 1e-8},
+        )
+
+    def test_RoughFrequencyCal_calibration(self):
+        """Test RoughFrequencyCal outputs a sensible answer."""
+
+        # cals = Calibrations.from_backend(self.simple_backend)
+        cals = Calibrations()
+
+        dur = Parameter("dur")
+        amp = Parameter("amp")
+        sigma = Parameter("sigma")
+        beta = Parameter("beta")
+        drive = pulse.DriveChannel(Parameter("ch0"))
+
+        # Define and add template schedules.
+        with pulse.build(name="x") as x:
+            pulse.play(pulse.Drag(dur, amp, sigma, beta), drive)
+
+        with pulse.build(name="sx") as sx:
+            pulse.play(pulse.Drag(dur, Parameter("amp"), sigma, Parameter("beta")), drive)
+
+        cals.add_schedule(x, num_qubits=1)
+        cals.add_schedule(sx, num_qubits=1)
+
+        for sched in ["x", "sx"]:
+            cals.add_parameter_value(80, "sigma", schedule=sched)
+            cals.add_parameter_value(0.5, "beta", schedule=sched)
+            cals.add_parameter_value(320, "dur", schedule=sched)
+            cals.add_parameter_value(0.5, "amp", schedule=sched)
+
+        freq_estimate = 5.005
+        frequencies = np.linspace(freq_estimate - 1e-2, freq_estimate + 1e-2, 51)
+
+        self.simple_backend.set_options(seed_simulator=5243234)
+        spec = RoughFrequencyCal(0, cals, frequencies, backend=self.simple_backend)
+        spec.set_experiment_options(amp=0.05, sigma=80, duration=320)
+
+        spec_data = spec.run().block_for_results()
+        freq_fit = spec_data.analysis_results("f01").value.nominal_value
+
+        self.assertTrue(np.abs(freq_fit - 5.0) < 1e-1)

--- a/test/dynamics/solvers/test_jax_odeint.py
+++ b/test/dynamics/solvers/test_jax_odeint.py
@@ -170,3 +170,13 @@ class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
         self.assertAllClose(
             self.jit_grad_wrap(sim_function)(2.0), 4 * (0.5 + (2.0**3 - 1.0**3) / 3)
         )
+    
+    def test_empty_integration(self):
+        """Test case for if t_span==[0., 0.]."""
+
+        result = jax_odeint(
+            rhs=self.simple_rhs,
+            t_span=np.array([0., 0.]),
+            y0=np.array([2.1])
+        )
+        self.assertAllClose(result.y, jnp.array([[2.1], [2.1]]))

--- a/test/dynamics/solvers/test_jax_odeint.py
+++ b/test/dynamics/solvers/test_jax_odeint.py
@@ -169,13 +169,9 @@ class TestJaxOdeint(QiskitDynamicsTestCase, TestJaxBase):
         self.assertAllClose(
             self.jit_grad_wrap(sim_function)(2.0), 4 * (0.5 + (2.0**3 - 1.0**3) / 3)
         )
-    
+
     def test_empty_integration(self):
         """Test case for if t_span==[0., 0.]."""
 
-        result = jax_odeint(
-            rhs=self.simple_rhs,
-            t_span=np.array([0., 0.]),
-            y0=np.array([2.1])
-        )
+        result = jax_odeint(rhs=self.simple_rhs, t_span=np.array([0.0, 0.0]), y0=np.array([2.1]))
         self.assertAllClose(result.y, jnp.array([[2.1], [2.1]]))

--- a/test/dynamics/solvers/test_solver_utils.py
+++ b/test/dynamics/solvers/test_solver_utils.py
@@ -261,7 +261,7 @@ class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
         self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5]]))
 
     def test_trim_t_results_with_overlap(self):
-        """Test trim_t_results when t_eval and t_span have overlap. Override original test
+        """Test trim_t_results_jax when t_eval and t_span have overlap. Override original test
         to validate the correct entry is being taken.
         """
 
@@ -276,3 +276,19 @@ class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
 
         self.assertAllClose(trimmed_obj.t, np.array([0.0, 1.0, 2.0]))
         self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]]))
+    
+    def test_trim_t_results_empty_integration(self):
+        """Test trim_t_results_jax for cases when results.t[-1] == results.t[0]. Should duplicate
+        result.y[0] into result.y[-1].
+        """
+
+        # empty object to assign attributes to
+        empty_obj = type("", (), {})()
+
+        empty_obj.t = np.array([1.0, 1.0])
+        empty_obj.y = np.array([[0.0, 1.0], [1.0, 0.0]])
+
+        trimmed_obj = self.trim_t_results(empty_obj)
+
+        self.assertAllClose(trimmed_obj.t, np.array([1.0, 1.0]))
+        self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.0, 1.0]]))

--- a/test/dynamics/solvers/test_solver_utils.py
+++ b/test/dynamics/solvers/test_solver_utils.py
@@ -276,7 +276,7 @@ class TestTimeArgsHandlingJAX(TestTimeArgsHandling, TestJaxBase):
 
         self.assertAllClose(trimmed_obj.t, np.array([0.0, 1.0, 2.0]))
         self.assertAllClose(trimmed_obj.y, np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]]))
-    
+
     def test_trim_t_results_empty_integration(self):
         """Test trim_t_results_jax for cases when results.t[-1] == results.t[0]. Should duplicate
         result.y[0] into result.y[-1].


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR contains several modifications to `DynamicsBackend` that fix small issues discovered while preparing a tutorial for the class.

### Details and comments

The changes:
- The default absolute tolerance on `_get_dressed_state_decomposition` has been reduced to `1e-5`, to be consistent with the Hermiticity checking in the `quantum_info` module. The previous absolute tolerance of `1e-8` was erroneously raising errors when dealing with Hamiltonians specified in Hz/s containing parameters in the GHz range.
    - No tests have been added for this as it's just a tolerance change.
- The way the default measurement instructions are built in the `DynamicsBackend` constructor has been changed to be more in line with my understanding of what the "right" way of adding instructions is: calling `target.add_instruction`. (Previously, the instructions were being added directly to the `instruction_schedule_map`, which wasn't properly populating all fields in the `target`).
    - No specific tests have been added for this, but all `DynamicsBackend` tests invariably indirectly test this.
- Experiment metadata is now being extracted and added to the `ExperimentResult` objects. `qiskit-experiments` uses metadata, and without this, analysis tasks were failing.
    - A new test has been added for this to check output metadata when submitting multiple circuits.
- `qiskit-experiments` expects jobs to have `time_per_step` method that returns time stamps, which `DynamicsJob` was not constructing. I've added some timestamp storing internally to `DynamicsJob` that can be retrieved by the `time_per_step`.
    - A test has been added confirm this and its behaviour. 
- Lastly, I found a bug in which, if a schedule being simulated has no instructions before measurement, the returned statevector would contain `nan` if using JAX and `jax_odeint`. This was due to `jax_odeint` being called with `t_span=[0., 0.]`, and this is another case in which `odeint` being called with non-unique time values, some of the returned states will be `nan`. I've updated `trim_t_results_jax` to detect when this is occurring and correct the returned state, which resolved the bug. (This came up as one of the experiments from `qiskit-experiments` appears to measure SPAM error by submitting a schedule with nothing occurring before measurement.)
    - I've added tests for both `trim_t_results_jax` and `jax_odeint` that would have detected this problem.
- This PR also adds a test that the `RoughFrequencyCal` experiment from `qiskit-experiments` can be run using `DynamicsBackend`, and returns a sensible result. This is contained in the new test file `test.dynamics.backend.test_qiskit_experiments`, and `qiskit-experiments` has been added to `requirements-dev.txt`.