### PR TITLE
Add DynamicsBackend channel methods

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -467,8 +467,7 @@ class DynamicsBackend(BackendV2):
         for x in qubits:
             if x not in self.options.control_channel_map:
                 raise QiskitError(f"Key {x} not in control_channel_map.")
-            idx = self.options.control_channel_map[x]
-            control_channels.append(pulse.ControlChannel(idx))
+            control_channels.append(pulse.ControlChannel(self.options.control_channel_map[x]))
 
         return control_channels
 

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -429,7 +429,7 @@ class DynamicsBackend(BackendV2):
 
     def control_channel(
         self, qubits: Union[Tuple[int, int], List[Tuple[int, int]]]
-    ) -> pulse.ControlChannel:
+    ) -> List[pulse.ControlChannel]:
         """Return the control channel with a given label specified by qubits.
 
         This method requires the ``control_channel_map`` option is set, and otherwise will raise
@@ -440,7 +440,8 @@ class DynamicsBackend(BackendV2):
         Returns:
             A list containing the control channels specified by qubits.
         Raises:
-            NotImplementedError: if the control_channel_map option is not set for this backend.
+            NotImplementedError: If the control_channel_map option is not set for this backend.
+            QiskitError: If a requested channel is not in the control_channel_map.
         """
         if self.options.control_channel_map is None:
             raise NotImplementedError
@@ -448,7 +449,14 @@ class DynamicsBackend(BackendV2):
         if not isinstance(qubits, list):
             qubits = [qubits]
 
-        return [pulse.ControlChannel(self.options.control_channel_map[x]) for x in qubits]
+        control_channels = []
+        for x in qubits:
+            if x not in self.options.control_channel_map:
+                raise QiskitError(f"Key {x} not in control_channel_map.")
+            idx = self.options.control_channel_map[x]
+            control_channels.append(pulse.ControlChannel(idx))
+
+        return control_channels
 
 
 def default_experiment_result_function(

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -405,7 +405,7 @@ class DynamicsBackend(BackendV2):
         return self.options.meas_map
 
     def _get_qubit_channel(
-        self, qubit: int, ChannelClass: pulse.channels.PulseChannel, method_name: str
+        self, qubit: int, ChannelClass: pulse.channels.Channel, method_name: str
     ):
         """Construct a channel instance for a given qubit."""
         if qubit in self.options.subsystem_labels:

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -233,7 +233,7 @@ class DynamicsBackend(BackendV2):
                             "The control_channel_map option must either be None or a dictionary."
                         )
                     if not all(isinstance(x, int) for x in value.values()):
-                        raise QiskitError("The control_channel_map values must all be of type int.")
+                        raise QiskitError("The control_channel_map values must be of type int.")
 
             if key == "solver":
                 self._set_solver(value)

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -164,15 +164,37 @@ class TestDynamicsBackendValidation(QiskitDynamicsTestCase):
 
         with self.assertRaisesRegex(QiskitError, "must be callable."):
             self.simple_backend.set_options(experiment_result_function=1)
-    
+
+    def test_not_implemented_control_channel_map(self):
+        """Test raising of NotImplementError if control_channel called when no control_channel_map
+        specified.
+        """
+
+        with self.assertRaises(NotImplementedError):
+            self.simple_backend.control_channel((0, 1))
+
     def test_invalid_control_channel_map(self):
         """Test setting an invalid control_channel_map raises an error."""
 
         with self.assertRaisesRegex(QiskitError, "None or a dictionary"):
             self.simple_backend.set_options(control_channel_map=1)
-        
+
         with self.assertRaisesRegex(QiskitError, "values must be of type int"):
             self.simple_backend.set_options(control_channel_map={(0, 1): "3"})
+
+    def test_invalid_drive_channel(self):
+        """Test requesting an invalid drive channel."""
+
+        with self.assertRaisesRegex(QiskitError, "drive_channel requested for qubit 10"):
+            self.simple_backend.drive_channel(10)
+
+    def test_invalid_control_channel(self):
+        """Test requesting an invalid control channel."""
+
+        self.simple_backend.set_options(control_channel_map={(0, 1): 0})
+
+        with self.assertRaisesRegex(QiskitError, "Key wow not in control_channel_map."):
+            self.simple_backend.control_channel("wow")
 
 
 class TestDynamicsBackend(QiskitDynamicsTestCase):
@@ -464,6 +486,26 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
             experiment_result_function=exp_result_function,
         ).result()
         self.assertDictEqual(result.get_counts(), {"3": 1})
+
+    def test_drive_channel(self):
+        """Test drive_channel method."""
+
+        channel = self.simple_backend.drive_channel(0)
+        self.assertTrue(isinstance(channel, pulse.DriveChannel))
+        self.assertTrue(channel.index == 0)
+
+    def test_control_channel(self):
+        """Test setting control_channel_map and retriving channel via the control_channel method."""
+
+        self.simple_backend.set_options(control_channel_map={(0, 1): 1})
+
+        channel = self.simple_backend.control_channel((0, 1))
+        self.assertTrue(isinstance(channel, list))
+        self.assertTrue(len(channel) == 1)
+
+        channel = channel[0]
+        self.assertTrue(isinstance(channel, pulse.ControlChannel))
+        self.assertTrue(channel.index == 1)
 
 
 class Test_default_experiment_result_function(QiskitDynamicsTestCase):

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -164,6 +164,15 @@ class TestDynamicsBackendValidation(QiskitDynamicsTestCase):
 
         with self.assertRaisesRegex(QiskitError, "must be callable."):
             self.simple_backend.set_options(experiment_result_function=1)
+    
+    def test_invalid_control_channel_map(self):
+        """Test setting an invalid control_channel_map raises an error."""
+
+        with self.assertRaisesRegex(QiskitError, "None or a dictionary"):
+            self.simple_backend.set_options(control_channel_map=1)
+        
+        with self.assertRaisesRegex(QiskitError, "values must be of type int"):
+            self.simple_backend.set_options(control_channel_map={(0, 1): "3"})
 
 
 class TestDynamicsBackend(QiskitDynamicsTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #144

Adds `drive_channel`, `measure_channel`, `acquire_channel`, and `control_channel` methods to `DynamicsBackend`, and includes tests for these methods.

### Details

The `drive_channel`, `measure_channel`, and `acquire_channel` methods first check if the requested qubit index is in `options.subsystem_list`, and if so, returns `pulse.ChannelClass(qubit)` (where `ChannelClass` is either `DriveChannel`, `MeasureChannel`, or `AcquireChannel`).

As there isn't an automatic relationship between control channels and any existing backend parameters, to implement `control_channel`, a further option, `control_channel_map`, has been added. This is a user-specified dictionary indication a mapping between control channel labels and control channel indices. E.g. a control channel map specified as `{(0, 1): 0}` could be used to indicate that the control channel associated with a CR drive from qubit 0 with target 1 is `pulse.ControlChannel(0)`. If this option is specified, then `control_channel` uses the dictionary to return the correct `ControlChannel` instance. The default for the option is `None`. When `None`, the `control_channel` will raise a `NotImplementedError`, which is the default behaviour from the base class.

Tests have been added to verify validation steps are working, and that the methods return the correct channels.