### PR TITLE
Fix t_span construction in DynamicsBackend

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -595,7 +595,8 @@ def _get_acquire_instruction_timings(
             if acquire_time != schedule_acquire_times[0]:
                 raise QiskitError("DynamicsBackend.run only supports measurements at one time.")
 
-        acquire_time_list.append(schedule_acquire_times[0])
+        # use dt to convert acquire start time from samples to to the integration interval
+        t_span_list.append([0.0, dt*schedule_acquire_times[0]])
         measurement_subsystems = []
         memory_slot_indices = []
         for inst in schedule_acquires:

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -613,10 +613,7 @@ def _get_acquire_instruction_timings(
         measurement_subsystems_list.append(measurement_subsystems)
         memory_slot_indices_list.append(memory_slot_indices)
 
-    # convert acquire start times specified as samples to the integration interval
-    t_span = [[0.0, x * dt] for x in acquire_time_list]
-
-    return t_span, measurement_subsystems_list, memory_slot_indices_list
+    return t_span_list, measurement_subsystems_list, memory_slot_indices_list
 
 
 def _to_schedule_list(

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -311,8 +311,7 @@ class DynamicsBackend(BackendV2):
             memory_slot_indices_list,
         ) = _get_acquire_data(schedules, backend.options.subsystem_labels)
 
-        dt = self.options.solver._dt
-        t_span = [[0.0, x * dt] for x in acquire_time_list]
+        t_span = [[0.0, x * self.options.solver._dt] for x in acquire_time_list]
 
         # Build and submit job
         job_id = str(uuid.uuid4())

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -564,7 +564,7 @@ def _get_acquire_instruction_timings(
         valid_subsystem_labels: Valid acquire channel indices. 
         dt: The sample size.
     Returns:
-        A Tuple of Lists containing, for each schedule: the list of integration intervals required
+        A tuple of lists containing, for each schedule: the list of integration intervals required
         for each schedule (in absolute time, from 0.0 to the beginning of the acquire instructions),
         a list of the subsystems being measured, and a list of the memory slots indices in which to
         store the results of each subsystem measurement.

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -560,8 +560,8 @@ def _get_acquire_instruction_timings(
     ``valid_subsystem_labels``.
 
     Args:
-        schedules: A list of schedules. 
-        valid_subsystem_labels: Valid acquire channel indices. 
+        schedules: A list of schedules.
+        valid_subsystem_labels: Valid acquire channel indices.
         dt: The sample size.
     Returns:
         A tuple of lists containing, for each schedule: the list of integration intervals required
@@ -572,7 +572,7 @@ def _get_acquire_instruction_timings(
         QiskitError: If a schedule contains no measurement, if a schedule contains measurements at
             different times, or if a measurement has an invalid subsystem label.
     """
-    acquire_time_list = []
+    t_span_list = []
     measurement_subsystems_list = []
     memory_slot_indices_list = []
     for schedule in schedules:
@@ -595,8 +595,8 @@ def _get_acquire_instruction_timings(
             if acquire_time != schedule_acquire_times[0]:
                 raise QiskitError("DynamicsBackend.run only supports measurements at one time.")
 
-        # use dt to convert acquire start time from samples to to the integration interval
-        t_span_list.append([0.0, dt*schedule_acquire_times[0]])
+        # use dt to convert acquire start time from sample index to the integration interval
+        t_span_list.append([0.0, dt * schedule_acquire_times[0]])
         measurement_subsystems = []
         memory_slot_indices = []
         for inst in schedule_acquires:

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -560,8 +560,9 @@ def _get_acquire_instruction_timings(
     ``valid_subsystem_labels``.
 
     Args:
-        schedules: A list of ``Schedule`` instances. valid_subsystem_labels: Valid acquire channel
-        indices. dt: The sample size.
+        schedules: A list of schedules. 
+        valid_subsystem_labels: Valid acquire channel indices. 
+        dt: The sample size.
     Returns:
         A Tuple of Lists containing, for each schedule: the list of integration intervals required
         for each schedule (in absolute time, from 0.0 to the beginning of the acquire instructions),

--- a/test/dynamics/backend/test_backend_utils.py
+++ b/test/dynamics/backend/test_backend_utils.py
@@ -90,7 +90,7 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
 
         output = _get_lab_frame_static_hamiltonian(model)
         self.assertAllClose(output, self.Z + self.X)
-    
+
     @unpack
     @data(("dense",), ("sparse",))
     def test_HamiltonianModel_diagonal(self, evaluation_mode):
@@ -140,7 +140,7 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
 
         output = _get_lab_frame_static_hamiltonian(model)
         self.assertAllClose(output, self.Z + self.X)
-    
+
     @unpack
     @data(("dense",), ("sparse",), ("dense_vectorized",), ("sparse_vectorized",))
     def test_LindbladModel_diagonal(self, evaluation_mode):

--- a/test/dynamics/backend/test_backend_utils.py
+++ b/test/dynamics/backend/test_backend_utils.py
@@ -90,6 +90,20 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
 
         output = _get_lab_frame_static_hamiltonian(model)
         self.assertAllClose(output, self.Z + self.X)
+    
+    @unpack
+    @data(("dense",), ("sparse",))
+    def test_HamiltonianModel_diagonal(self, evaluation_mode):
+        """Test correct functioning on HamiltonianModel with explicitly diagonal frame."""
+        model = HamiltonianModel(
+            static_operator=self.Z + self.X,
+            operators=[self.X],
+            rotating_frame=np.diag(self.Z),
+            evaluation_mode=evaluation_mode,
+        )
+
+        output = _get_lab_frame_static_hamiltonian(model)
+        self.assertAllClose(output, self.Z + self.X)
 
     @unpack
     @data(("dense",), ("sparse",))
@@ -121,6 +135,21 @@ class TestLabFrameStaticHamiltonian(QiskitDynamicsTestCase):
             static_hamiltonian=self.Z + self.X,
             hamiltonian_operators=[self.X],
             rotating_frame=self.X,
+            evaluation_mode=evaluation_mode,
+        )
+
+        output = _get_lab_frame_static_hamiltonian(model)
+        self.assertAllClose(output, self.Z + self.X)
+    
+    @unpack
+    @data(("dense",), ("sparse",), ("dense_vectorized",), ("sparse_vectorized",))
+    def test_LindbladModel_diagonal(self, evaluation_mode):
+        """Test correct functioning on LindbladModel with explicitly diagonal frame."""
+
+        model = LindbladModel(
+            static_hamiltonian=self.Z + self.X,
+            hamiltonian_operators=[self.X],
+            rotating_frame=np.diag(self.Z),
             evaluation_mode=evaluation_mode,
         )
 

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -261,7 +261,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
         result = self.simple_backend.run(
             schedule, seed_simulator=398472, initial_state=DensityMatrix([1.0, 0.0])
         ).result()
-        self.assertDictEqual(result.get_counts(), {"0": 505, "1": 519})
+        self.assertDictEqual(result.get_counts(), {"0": 513, "1": 511})
 
         result = result = self.simple_backend.run(
             schedule,
@@ -272,7 +272,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
         ).result()
 
         counts = self.iq_to_counts(result.get_memory())
-        self.assertDictEqual(counts, {"0": 499, "1": 525})
+        self.assertDictEqual(counts, {"0": 510, "1": 514})
 
     def test_pi_half_pulse_relabelled(self):
         """Test simulation of a pi/2 pulse with qubit relabelled."""
@@ -285,7 +285,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
                 pulse.acquire(duration=1, qubit_or_channel=1, register=pulse.MemorySlot(1))
 
         result = self.simple_backend.run(schedule, seed_simulator=398472).result()
-        self.assertDictEqual(result.get_counts(), {"00": 505, "10": 519})
+        self.assertDictEqual(result.get_counts(), {"00": 513, "10": 511})
 
     def test_circuit_with_pulse_defs(self):
         """Test simulating a circuit with pulse definitions."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #185 

See the above issue for a more detailed description, but this PR fixes a bug in which `DynamicsBackend` was using the wrong integration interval in `schedule` simulations: the times were passed as sample times, rather than as sample times `* dt` (the sample width). 

### Details and comments

The private function `dynamics_backend._get_acquire_data` has been updated to return a list of only acquire times for each schedule (as opposed to something with the shape of `t_span` that should be passed to `solve`). The documentation of this function has also been updated to clearly state this is what it is doing. After `_get_acquire_data` is called within `DynamicsBackend.run`, this is translated to the `t_span` argument by constructing the integration intervals with the correct samples times multiplied by `dt`.

At the moment, the PR does not directly test this change, as it occurs within inaccessible code. One option is to modify the `_get_acquire_data` function to return the constructed `t_span` value, and then we could add tests for that function, however since this function works only with schedules, it feels more natural for it to work purely with sample times.

This PR does however add tests for diagonally-specified rotating frames for the `_get_dressed_state_decomposition` utility function. While this turned out to be unrelated to this issue, I noticed this case was being missed in these tests.
