### PR TITLE
changing license link from an experiments to dynamics link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qiskit Dynamics
 
-[![License](https://img.shields.io/github/license/Qiskit/qiskit-experiments.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/github/license/Qiskit/qiskit-dynamics.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)
 
 **This repo is still in the early stages of development, there will be breaking API changes**
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Just noticed the license link in the readme was linking to a `qiskit-experiments` link rather than `qiskit-dynamics`.

