### PR TITLE
Temporary JAX fix for tests

### DIFF
--- a/test/dynamics/__init__.py
+++ b/test/dynamics/__init__.py
@@ -13,3 +13,8 @@
 """
 Qiskit Dynamics tests
 """
+
+# temporarily disable a change in JAX 0.4.4 that introduced a bug. Must be run before importing JAX
+import os
+
+os.environ["JAX_JIT_PJIT_API_MERGE"] = "0"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The recent JAX 0.4.4 update has broken testing for the perturbation module. The discussion in the JAX repo is [here](https://github.com/google/jax/discussions/14561), and has similar characteristics to a similar issue that was introduced and discussed a year ago [here](https://github.com/google/jax/discussions/9951) (the same minimal example works in both cases).

The JAX changelog indicates that running the lines:
```
import os

os.environ["JAX_JIT_PJIT_API_MERGE"] = "0"
```
before importing JAX will disable the major change associated with this release that seems to be causing the problem.

This PR adds this to the `__init__.py` file in the testing folder, to get the CI tests to run.