### PR TITLE
[WIP]Arraylias integration

### DIFF
--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -629,10 +629,10 @@ class DiscreteSignalSum(DiscreteSignal, SignalSum):
     def __init__(
         self,
         dt: float,
-        samples: Union[List, Array],
+        samples: List,
         start_time: float = 0.0,
-        carrier_freq: Union[List, np.array, Array] = None,
-        phase: Union[List, np.array, Array] = None,
+        carrier_freq: Union[List, np.array, jnp.array] = None,
+        phase: Union[List, np.array, jnp.array] = None,
         name: str = None,
     ):
         r"""Directly initialize a ``DiscreteSignalSum``\. Samples of all terms in the
@@ -649,12 +649,12 @@ class DiscreteSignalSum(DiscreteSignal, SignalSum):
             name: name of the signal.
         """
 
-        samples = Array(samples)
+        samples = unp.asarray(samples)
         if carrier_freq is None:
-            carrier_freq = np.zeros(samples.shape[-1], dtype=float)
+            carrier_freq = unp.zeros(samples.shape[-1], dtype=float)
 
         if phase is None:
-            phase = np.zeros(samples.shape[-1], dtype=float)
+            phase = unp.zeros(samples.shape[-1], dtype=float)
 
         DiscreteSignal.__init__(
             self,
@@ -718,13 +718,13 @@ class DiscreteSignalSum(DiscreteSignal, SignalSum):
             DiscreteSignalSum: The discretized ``SignalSum``\.
         """
 
-        times = start_time + (np.arange(n_samples) + 0.5) * dt
+        times = start_time + (unp.arange(n_samples) + 0.5) * dt
 
         freq = signal_sum.carrier_freq
 
         if sample_carrier:
             freq = 0.0 * freq
-            exp_phases = np.exp(np.expand_dims(Array(times), -1) * signal_sum._carrier_arg)
+            exp_phases = unp.exp(unp.expand_dims(unp.asarray(times), -1) * signal_sum._carrier_arg)
             samples = signal_sum.envelope(times) * exp_phases
         else:
             samples = signal_sum.envelope(times)
@@ -752,7 +752,7 @@ class DiscreteSignalSum(DiscreteSignal, SignalSum):
 
         return default_str
 
-    def __getitem__(self, idx: Union[int, List, np.array, slice]) -> Signal:
+    def __getitem__(self, idx: Union[int, List, np.array, jnp.array, slice]) -> Signal:
         """Enables numpy-style subscripting, as if this class were a 1d array."""
 
         if type(idx) == int and idx >= len(self):
@@ -763,13 +763,13 @@ class DiscreteSignalSum(DiscreteSignal, SignalSum):
         phases = self.phase[idx]
 
         if samples.ndim == 1:
-            samples = Array([samples])
+            samples = unp.asarray([samples])
 
         if carrier_freqs.ndim == 0:
-            carrier_freqs = Array([carrier_freqs])
+            carrier_freqs = unp.asarray([carrier_freqs])
 
         if phases.ndim == 0:
-            phases = Array([phases])
+            phases = unp.asarray([phases])
 
         if len(samples) == 1:
             return DiscreteSignal(

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -27,8 +27,6 @@ from matplotlib import pyplot as plt
 from qiskit import QiskitError
 from arraylias import numpy_alias
 
-from qiskit_dynamics.array import Array
-
 try:
     import jax.numpy as jnp
 except ImportError:

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -155,12 +155,12 @@ class Signal:
         # TODO: reorganize type hints of an attribute and a return type
         """Vectorized evaluation of the complex value at time t."""
         arg = self._carrier_arg * t + self._phase_arg
-        return self.envelope(t) * np.exp(arg)
+        return self.envelope(t) * unp.exp(arg)
 
     def __call__(self, t: Union[float, np.ndarray]) -> Union[complex, np.ndarray]:
         # TODO: reorganize type hints of an attribute and a return type
         """Vectorized evaluation of the signal at time(s) t."""
-        return np.real(self.complex_value(t))
+        return unp.real(self.complex_value(t))
 
     def __str__(self) -> str:
         """Return string representation."""
@@ -315,6 +315,8 @@ class DiscreteSignal(Signal):
                     -1,
                     len(self.samples),
                 )
+            # print(idx)
+            # print(self._padded_samples)
             return self._padded_samples[idx]
 
         Signal.__init__(self, envelope=envelope, carrier_freq=carrier_freq, phase=phase, name=name)
@@ -810,8 +812,6 @@ class SignalList(SignalCollection):
     def __call__(self, t: Union[float, np.ndarray, jnp.ndarray]) -> Union[np.ndarray, jnp.ndarray]:
         """Vectorized evaluation of all components."""
         # TODO: reorganize type hints of an attribute and a return type
-        print('AAAAAAAa')
-        print(self._eval_signals(t))
         return unp.moveaxis(self._eval_signals(t), 0, -1)
 
     def flatten(self) -> "SignalList":

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -29,6 +29,11 @@ from arraylias import numpy_alias
 
 from qiskit_dynamics.array import Array
 
+try:
+    import jax.numpy as jnp
+except ImportError:
+    pass
+
 
 unp = numpy_alias()()
 
@@ -118,43 +123,44 @@ class Signal:
         return self._is_constant
 
     @property
-    def carrier_freq(self) -> Array:
+    def carrier_freq(self):
+        # TODO: specify a return type
         """The carrier frequency of the signal."""
         return self._carrier_freq
 
     @carrier_freq.setter
-    def carrier_freq(self, carrier_freq: Union[float, list, Array]):
+    def carrier_freq(self, carrier_freq: Union[float, list]):
         """Carrier frequency setter. List handling is to support subclasses storing a
         list of frequencies."""
-        if type(carrier_freq) == list:
-            carrier_freq = [Array(entry).data for entry in carrier_freq]
-        self._carrier_freq = Array(carrier_freq)
+        self._carrier_freq = unp.asarray(carrier_freq)
         self._carrier_arg = 1j * 2 * np.pi * self._carrier_freq
 
     @property
-    def phase(self) -> Array:
+    def phase(self):
+        # TODO: specify a return type
         """The phase of the signal."""
         return self._phase
 
     @phase.setter
-    def phase(self, phase: Union[float, list, Array]):
+    def phase(self, phase: Union[float, list]):
         """Phase setter. List handling is to support subclasses storing a
         list of phases."""
-        if type(phase) == list:
-            phase = [Array(entry).data for entry in phase]
-        self._phase = Array(phase)
+        self._phase = unp.asarray(phase)
         self._phase_arg = 1j * self._phase
 
-    def envelope(self, t: Union[float, np.array, Array]) -> Union[complex, np.array, Array]:
+    def envelope(self, t: Union[float, np.array]) -> Union[complex, np.array]:
+        # TODO: reorganize type hints of an attribute and a return type
         """Vectorized evaluation of the envelope at time t."""
         return self._envelope(t)
 
-    def complex_value(self, t: Union[float, np.array, Array]) -> Union[complex, np.array, Array]:
+    def complex_value(self, t: Union[float, np.array]) -> Union[complex, np.array]:
+        # TODO: reorganize type hints of an attribute and a return type
         """Vectorized evaluation of the complex value at time t."""
         arg = self._carrier_arg * t + self._phase_arg
         return self.envelope(t) * np.exp(arg)
 
-    def __call__(self, t: Union[float, np.array, Array]) -> Union[complex, np.array, Array]:
+    def __call__(self, t: Union[float, np.array]) -> Union[complex, np.array]:
+        # TODO: reorganize type hints of an attribute and a return type
         """Vectorized evaluation of the signal at time(s) t."""
         return np.real(self.complex_value(t))
 

--- a/qiskit_dynamics/signals/signals.py
+++ b/qiskit_dynamics/signals/signals.py
@@ -412,7 +412,7 @@ class DiscreteSignal(Signal):
     def conjugate(self):
         return self.__class__(
             dt=self._dt,
-            samples=np.conjugate(self.samples),
+            samples=unp.conjugate(self.samples),
             start_time=self._start_time,
             carrier_freq=-self.carrier_freq,
             phase=-self.phase,

--- a/test/dynamics/signals/test_signals.py
+++ b/test/dynamics/signals/test_signals.py
@@ -921,7 +921,6 @@ class TestSignalsJaxTransformations(QiskitDynamicsTestCase, TestJaxBase):
         self._test_jit_signal_eval(self.constant, t=2.1)
         self._test_jit_signal_eval(self.discrete_signal, t=2.1)
         self._test_jit_signal_eval(self.signal_sum, t=2.1)
-        print("test_jit_eval")
         self._test_jit_signal_eval(self.discrete_signal_sum, t=2.1)
 
     def test_jit_grad_constant_construct(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
At first, I try to migrate to arraylias in signals.py.
- Import `numpy_array()` from arraylias
- Set `unp = numpy_array()()`
- Be able to use `unp` like `np`.

It results in simplifying codes in dynamcis due to arraylias.

In addition, I changed only some parts of `np` to `unp`: 
E.g. np.append(A, B) makes A numpy.ndarray even if the type of A is jax.numpy.array. ``np.exp(A) is the same.
~On the other hand, for example, we don't need to change `np.real(A)`, which reflects the type of A.~
In JAX.jit, it is necessary to use jnp.real not np.real.

I haven't decided if all the files are migrated in only  this PR.


### Details and comments
JAX array almost supports numpy.array methods. But it doesn't all of them.
So it may be better if we can test whether all the methods used in a library are implemented both in numpy and jax. 
Of course, whether to incorporate this way into arraylias will be another issue.

