### PR TITLE
Enabling Qiskit docs analytics

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ html_theme_options = {
 }
 html_css_files = ['gallery.css']
 html_static_path = ['_static']
+html_context = {"analytics_enabled": True}
 
 # autodoc/autosummary options
 autosummary_generate = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ stestr>=3.0.0
 astroid==2.9.3
 pylint==2.12.2
 black~=22.0
-qiskit-sphinx-theme>=1.6
+qiskit-sphinx-theme~=1.10
 sphinx-autodoc-typehints
 jupyter-sphinx
 pygments>=2.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Enabling analytics for documentation page visits, per [qiskit_sphinx_theme analytics feature](https://github.com/Qiskit/qiskit_sphinx_theme#enable-qiskitorg-analytics)

This also adds **Was this page helpful?** clicker at the end of each doc page:   
![image](https://user-images.githubusercontent.com/46826214/222957613-9fc5db61-a9f5-4227-bc36-ce318beb70a7.png)




### Details and comments


