### PR TITLE
Fix error in schedule -> signal conversion for schedules with barrier instructions

### DIFF
--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -164,7 +164,7 @@ class InstructionToSignals:
 
         for start_sample, inst in schedule.instructions:
             # get channel name if instruction has it
-            chan = inst.channel.name if hasattr(inst, "channel") else None
+            chan = getattr(inst, "channel", None)
 
             if isinstance(inst, Play):
                 # get the instruction samples

--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -163,9 +163,9 @@ class InstructionToSignals:
             )
 
         for start_sample, inst in schedule.instructions:
-            chan = inst.channel.name
-            phi = phases[chan]
-            freq = frequency_shifts[chan]
+            # get channel name if instruction has it
+            chan = inst.channel.name if hasattr(inst, "channel") else None
+
             if isinstance(inst, Play):
                 # get the instruction samples
                 inst_samples = None
@@ -178,8 +178,8 @@ class InstructionToSignals:
                 times = self._dt * (start_sample + np.arange(len(inst_samples)))
                 samples = inst_samples * np.exp(
                     Array(
-                        2.0j * np.pi * freq * times
-                        + 1.0j * phi
+                        2.0j * np.pi * frequency_shifts[chan] * times
+                        + 1.0j * phases[chan]
                         + 2.0j * np.pi * phase_accumulations[chan]
                     )
                 )

--- a/qiskit_dynamics/pulse/pulse_to_signals.py
+++ b/qiskit_dynamics/pulse/pulse_to_signals.py
@@ -164,7 +164,7 @@ class InstructionToSignals:
 
         for start_sample, inst in schedule.instructions:
             # get channel name if instruction has it
-            chan = getattr(inst, "channel", None)
+            chan = inst.channel.name if hasattr(inst, "channel") else None
 
             if isinstance(inst, Play):
                 # get the instruction samples

--- a/releasenotes/notes/0.4/0.4-summary-3de98711c3b7aa09.yaml
+++ b/releasenotes/notes/0.4/0.4-summary-3de98711c3b7aa09.yaml
@@ -84,6 +84,9 @@ fixes:
     :class:`~qiskit.pulse.instructions.ShiftFrequency` instructions has also been fixed. (`#140
     <https://github.com/Qiskit/qiskit-dynamics/issues/140>`__)
   - |
+    :class:`.InstructionToSignals` has been updated to fix an error when parsing schedules that
+    include barrier instructions. `#202 <https://github.com/Qiskit/qiskit-dynamics/issues/202>`__)
+  - |
     Fixes a bug in the automatic jit-compilation of :meth:`Solver.solve` when using the ``t_eval``
     kwarg with a JAX method and ``Array.default_backend() == 'jax'``. The bug is fixed by updating
     the time-argument handling for the ``"jax_odeint"`` and Diffrax methods. The automatic jitting


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #202.

This fixes an error in the schedule -> signal converter when the schedule contained a barrier instruction.

### Details and comments

As described in #202, in the loop over instructions to construct the signals, there is a line `chan = inst.channel.name`, which assumes that `inst.channel` exists. Barrier instructions do not have a `channel` attribute, hence the error. This PR modifies this line to conditionally set `chan` based on whether `inst.channel` exists, and adds a test validating the correct parsing of a schedule with a barrier. Note that I've also removed the `phase` and `freq` variables set at the same time as `chan`, as they were only used in one subsequent line.

For completeness, the important thing to note here is that nothing actually needs to be done to "support" barrier instructions:
- Barrier instructions impact how `block_to_schedule` converts `ScheduleBlock` instances to `Schedule` instances.
- Once in `Schedule` form all instructions have explicit absolute timing, so the barrier instructions in the schedule are actually redundant.
- As the Dynamics schedule -> signal converter works with these absolute times, it can actually just ignore the barrier instructions when parsing a schedule.
- Hence, the problem arising in #202 is just a result of a trivial mishandling of the barrier instruction object.