### PR TITLE
Bug fix: Measurement properties automatic padding for DynamicsBackend initialization

### DIFF
--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -685,19 +685,22 @@ class DynamicsBackend(BackendV2):
 
         # Add control_channel_map from backend (only if not specified before by user)
         if "control_channel_map" not in options:
-            if hasattr(backend, "control_channels"):  # Look in backend.control_channels
-                control_channel_map_backend = {**{qubits: backend.control_channels[qubits][0].index
-                                                  for qubits in backend.control_channels}
-                                               }
+            if hasattr(backend, "control_channels"):
+                control_channel_map_backend = {
+                    qubits: backend.control_channels[qubits][0].index
+                    for qubits in backend.control_channels
+                }
 
-            elif hasattr(backend.configuration(), "control_channels"):  # Look in backend.configuration()
-                control_channel_map_backend = {**{qubits: backend.configuration().control_channels[qubits][0].index
-                                                  for qubits in backend.configuration().control_channels}
-                                               }
+            elif hasattr(backend.configuration(), "control_channels"):
+                control_channel_map_backend = {
+                    qubits: backend.configuration().control_channels[qubits][0].index
+                    for qubits in backend.configuration().control_channels
+                }
+
             else:
                 control_channel_map_backend = {}
 
-            # Reduce control_channel_map to match subsystem_list
+            # Reduce control_channel_map based on which channels are in the model
             if bool(control_channel_map_backend):
                 control_channel_map = {}
                 for label, idx in control_channel_map_backend.items():

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -211,9 +211,10 @@ class DynamicsBackend(BackendV2):
                         duration=1, qubit_or_channel=qubit, register=pulse.MemorySlot(qubit)
                     )
 
-            measure_properties[(qubit,)] = InstructionProperties(calibration=meas_sched)
+                measure_properties[(qubit,)] = InstructionProperties(calibration=meas_sched)
 
-        target.add_instruction(Measure(), measure_properties)
+        if bool(measure_properties):
+            target.add_instruction(Measure(), measure_properties)
 
         target.dt = solver._dt
 

--- a/qiskit_dynamics/backend/dynamics_backend.py
+++ b/qiskit_dynamics/backend/dynamics_backend.py
@@ -684,26 +684,29 @@ class DynamicsBackend(BackendV2):
         )
 
         # Add control_channel_map from backend (only if not specified before by user)
-        if not "control_channel_map" in options:
+        if "control_channel_map" not in options:
             control_channel_map = {}
-            if hasattr(backend, "control_channels"): # Look in backend.control_channels
+            if hasattr(backend, "control_channels"):  # Look in backend.control_channels
                 control_channel_map_backend = {**{qubits: backend.control_channels[qubits][0].index
                                                   for qubits in backend.control_channels}
                                                }
-            elif hasattr(backend, "coupling_map"): # Look in backend.coupling_map
+            elif hasattr(backend, "coupling_map"):  # Look in backend.coupling_map
                 control_channel_map_backend = {
                     **{qubits: backend.control_channel(qubits)[0].index for qubits in backend.coupling_map}
                 }
-            else: # Look in backend.configuration()
+            elif hasattr(backend.configuration(), "control_channels"):  # Look in backend.configuration()
                 control_channel_map_backend = {**{qubits: backend.configuration().control_channels[qubits][0].index
                                                   for qubits in backend.configuration().control_channels}
                                                }
+            else:
+                control_channel_map_backend = {}
 
             # Reduce control_channel_map to match subsystem_list
-            for qubits in control_channel_map_backend:
-                if qubits[0] in subsystem_list and qubits[1] in subsystem_list:
-                    control_channel_map[qubits] = control_channel_map_backend[qubits]
-            options["control_channel_map"] = control_channel_map
+            if bool(control_channel_map_backend):
+                for qubits in control_channel_map_backend:
+                    if qubits[0] in subsystem_list and qubits[1] in subsystem_list:
+                        control_channel_map[qubits] = control_channel_map_backend[qubits]
+                options["control_channel_map"] = control_channel_map
 
         # build the solver
         if rotating_frame == "auto":

--- a/releasenotes/notes/measurement_property_bug_fix-12461088823a943c.yaml
+++ b/releasenotes/notes/measurement_property_bug_fix-12461088823a943c.yaml
@@ -1,0 +1,19 @@
+---
+prelude: >
+    This release fixes a bug in the initialisation of a DynamicsBackend when a Target object was provided for the initialisation.
+    Furthermore, it also features the possibility to automatically load a control_channel_map from an existing backend when using 
+    DynamicsBackend.from_backend() method. 
+features:
+  - |
+    Initialising a DynamicsBackend instance using the from_backend() method now loads automatically the
+    control_channel_map of the original backend to the DynamicsBackend option "control_channel_map".
+    Note that if the user sets manually the option "control_channel_map", the provided option will overwrite 
+    The default map from the original backend. 
+
+fixes:
+  - |
+    A bug regarding the setting of the measurement properties at the initialisation of the
+    DynamicsBackend instance was always resetting the measurement instruction to a default setting 
+    even though there was already a measurement instruction stored in the provided Target object. This bug is now fixed
+    and the measurement instruction is added only if the designated qubit in the provided Target does not have a measurement instruction.
+

--- a/releasenotes/notes/measurement_property_bug_fix-12461088823a943c.yaml
+++ b/releasenotes/notes/measurement_property_bug_fix-12461088823a943c.yaml
@@ -1,19 +1,11 @@
 ---
-prelude: >
-    This release fixes a bug in the initialisation of a DynamicsBackend when a Target object was provided for the initialisation.
-    Furthermore, it also features the possibility to automatically load a control_channel_map from an existing backend when using 
-    DynamicsBackend.from_backend() method. 
 features:
   - |
-    Initialising a DynamicsBackend instance using the from_backend() method now loads automatically the
-    control_channel_map of the original backend to the DynamicsBackend option "control_channel_map".
-    Note that if the user sets manually the option "control_channel_map", the provided option will overwrite 
-    The default map from the original backend. 
+    The :meth:`DynamicsBackend.from_backend` method has been updated to automatically populate the 
+    `control_channel_map` option based on the supplied backend if the user does not supply one.
 
 fixes:
   - |
-    A bug regarding the setting of the measurement properties at the initialisation of the
-    DynamicsBackend instance was always resetting the measurement instruction to a default setting 
-    even though there was already a measurement instruction stored in the provided Target object. This bug is now fixed
-    and the measurement instruction is added only if the designated qubit in the provided Target does not have a measurement instruction.
+    A bug in :meth:`DynamicsBackend.__init__` causing existing measurement instructions for a user-supplied
+    :class:`Target` has been fixed.
 

--- a/releasenotes/notes/measurement_property_bug_fix-12461088823a943c.yaml
+++ b/releasenotes/notes/measurement_property_bug_fix-12461088823a943c.yaml
@@ -7,5 +7,5 @@ features:
 fixes:
   - |
     A bug in :meth:`DynamicsBackend.__init__` causing existing measurement instructions for a user-supplied
-    :class:`Target` has been fixed.
+    :class:`Target` to be overwritten has been fixed.
 

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -18,7 +18,6 @@ Test DynamicsBackend.
 from types import SimpleNamespace
 
 import numpy as np
-from qiskit.pulse import ControlChannel
 from scipy.integrate._ivp.ivp import OdeResult
 from scipy.sparse import csr_matrix
 
@@ -554,7 +553,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
     def test_valid_measurement_properties(self):
         """Test that DynamicsBackend instantiation always carries measurement instructions."""
 
-        # Case where no measurement instruction is added manually (which is the case for self.simple_backend)
+        # Case where no measurement instruction is added manually
         instruction_schedule_map = self.backend_2q.target.instruction_schedule_map()
         for q in range(self.simple_backend.num_qubits):
             self.assertTrue(instruction_schedule_map.has(instruction="measure", qubits=q))
@@ -669,14 +668,14 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
         ]
 
         configuration.control_channels = {
-            (0, 1): [ControlChannel(0)],
-            (1, 0): [ControlChannel(1)],
-            (1, 2): [ControlChannel(2)],
-            (2, 1): [ControlChannel(3)],
-            (1, 3): [ControlChannel(4)],
-            (3, 1): [ControlChannel(5)],
-            (3, 4): [ControlChannel(6)],
-            (4, 3): [ControlChannel(7)],
+            (0, 1): [pulse.ControlChannel(0)],
+            (1, 0): [pulse.ControlChannel(1)],
+            (1, 2): [pulse.ControlChannel(2)],
+            (2, 1): [pulse.ControlChannel(3)],
+            (1, 3): [pulse.ControlChannel(4)],
+            (3, 1): [pulse.ControlChannel(5)],
+            (3, 4): [pulse.ControlChannel(6)],
+            (4, 3): [pulse.ControlChannel(7)],
         }
 
         defaults = SimpleNamespace()
@@ -891,8 +890,8 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
         self.assertAllClose(expected_operators / 1e9, solver.model.operators / 1e9)
 
     def test_setting_control_channel_map(self):
-        """Test if control_channel_map argument is correctly set in DynamicsBackend options from the original
-        backend control_channel_map."""
+        """Test automatic padding of control_channel_map in DynamicsBackend
+        options from original backend."""
 
         # Check that manual setting of the map overrides the one from original backend
         control_channel_map = {(0, 1): 4}
@@ -901,7 +900,7 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
         )
         self.assertDictEqual(backend.options.control_channel_map, {(0, 1): 4})
 
-        # Check that control_channel_map from original backend is correctly set in the DynamicsBackend.options
+        # Check that control_channel_map from original backend is set in DynamicsBackend.options
         backend = DynamicsBackend.from_backend(self.valid_backend)
         self.assertDictEqual(
             backend.options.control_channel_map,

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -18,11 +18,12 @@ Test DynamicsBackend.
 from types import SimpleNamespace
 
 import numpy as np
+from qiskit.pulse import ControlChannel
 from scipy.integrate._ivp.ivp import OdeResult
 from scipy.sparse import csr_matrix
 
 from qiskit import QiskitError, pulse, QuantumCircuit
-from qiskit.circuit.library import XGate
+from qiskit.circuit.library import XGate, Measure
 from qiskit.transpiler import Target, InstructionProperties
 from qiskit.quantum_info import Statevector, DensityMatrix
 from qiskit.result.models import ExperimentResult, ExperimentResultData
@@ -264,6 +265,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
             dt=0.1,
             rotating_frame=static_ham_2q,
         )
+        self.solver_2q = solver_2q
         self.backend_2q = DynamicsBackend(solver=solver_2q, subsystem_dims=[2, 2])
 
         # function to discriminate 0 and 1 for default centers.
@@ -550,6 +552,40 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
         self.assertDictEqual(res.results[1].header.metadata, {"key1": "value1"})
 
 
+    def test_valid_measurement_properties(self):
+        """Test that DynamicsBackend instantiation always carries measurement instructions"""
+
+        # Case where no measurement instruction is added manually (which is the case for self.simple_backend)
+        instruction_schedule_map = self.backend_2q.target.instruction_schedule_map()
+        assert instruction_schedule_map.has(instruction='measure', qubits=self.simple_backend.num_qubits)
+        for q in range(self.simple_backend.num_qubits):
+            assert isinstance(instruction_schedule_map.get('measure', q).instructions[0][1], pulse.Acquire)
+            assert len(instruction_schedule_map.get('measure', q).instructions) == 1
+
+        # Case where measurement instruction is added manually
+        custom_meas_duration = 3
+        with pulse.build() as meas_sched0:
+            pulse.acquire(
+                duration=custom_meas_duration, qubit_or_channel=0, register=pulse.MemorySlot(0)
+            )
+
+        with pulse.build() as meas_sched1:
+            pulse.acquire(
+                duration=custom_meas_duration, qubit_or_channel=1, register=pulse.MemorySlot(1)
+            )
+
+        measure_properties = {(0,): InstructionProperties(calibration=meas_sched0),
+                              (1,): InstructionProperties(calibration=meas_sched1)}
+        target = Target()
+        target.add_instruction(Measure(), measure_properties)
+        custom_meas_backend = DynamicsBackend(solver=self.solver_2q, target=target, subsystem_dims=[2, 2])
+        instruction_schedule_map = custom_meas_backend.target.instruction_schedule_map()
+        for q in range(self.simple_backend.num_qubits):
+            assert isinstance(instruction_schedule_map.get('measure', q).instructions[0][1], pulse.Acquire)
+            assert len(instruction_schedule_map.get('measure', q).instructions) == 1
+            assert instruction_schedule_map.get('measure', q).instructions[0][1].duration == custom_meas_duration
+
+
 class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
     """Test class for DynamicsBackend.from_backend and resulting DynamicsBackend instances."""
 
@@ -617,6 +653,18 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
             [UchannelLO(3, (1 + 0j))],
         ]
 
+        configuration.control_channels = {(0, 1): [ControlChannel(0)],
+                                          (1, 0): [ControlChannel(1)],
+                                          (1, 2): [ControlChannel(2)],
+                                          (2, 1): [ControlChannel(3)],
+                                          (1, 3): [ControlChannel(4)],
+                                          (3, 1): [ControlChannel(5)],
+                                          (3, 4): [ControlChannel(6)],
+                                          (4, 3): [ControlChannel(7)]
+                                          }
+        configuration.coupling_map = [[0, 1], [1, 0], [1, 2], [2, 1],
+                                      [1, 3], [3, 1], [3, 4], [4, 3]]
+
         defaults = SimpleNamespace()
         defaults.qubit_freq_est = [
             5175383639.513607,
@@ -630,6 +678,7 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
         backend = SimpleNamespace()
         backend.configuration = lambda: configuration
         backend.defaults = lambda: defaults
+        backend.control_channels = backend.configuration().control_channels
 
         self.valid_backend = backend
 
@@ -827,6 +876,32 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
         )
         self.assertAllClose(expected_operators / 1e9, solver.model.operators / 1e9)
 
+    def test_setting_control_channel_map(self):
+        """Test if control_channel_map argument is correctly set in the DynamicsBackend options from the original
+        backend control_channel_map (or coupling_map)"""
+
+        # Check that manual setting of the map overrides the one from original backend
+        control_channel_map = {(0, 1): 4                                  }
+        backend = DynamicsBackend.from_backend(self.valid_backend, control_channel_map=control_channel_map)
+        assert backend.options.control_channel_map == {(0, 1): 4}
+
+        # Check that control_channel_map from original backend is correctly set in the DynamicsBackend.options
+        backend = DynamicsBackend.from_backend(self.valid_backend)
+        assert backend.options.control_channel_map == {(0, 1): 0, (1, 0): 1,
+                                                       (1, 2): 2, (2, 1): 3,
+                                                       (1, 3): 4, (3, 1): 5,
+                                                       (3, 4): 6, (4, 3): 7
+                                                       }
+
+        # Check that reduction to subsystem_list is correct
+        backend = DynamicsBackend.from_backend(self.valid_backend, subsystem_list=[0, 1, 2])
+        assert backend.options.control_channel_map == {(0, 1): 0, (1, 0): 1,
+                                                       (1, 2): 2, (2, 1): 3,
+                                                       }
+
+        # Check that manually setting the option after the declaration overwrites the previous map
+        backend.set_options(control_channel_map = {(0, 1): 3})
+        assert backend.options.control_channel_map == {(0, 1): 3}
 
 class Test_default_experiment_result_function(QiskitDynamicsTestCase):
     """Test default_experiment_result_function."""

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -593,7 +593,7 @@ class TestDynamicsBackend(QiskitDynamicsTestCase):
                     instruction_schedule_map.get("measure", q).instructions[0][1], pulse.Acquire
                 )
             )
-            self.assertEqual(instruction_schedule_map.get("measure", q).instructions, 1)
+            self.assertEqual(len(instruction_schedule_map.get("measure", q).instructions), 1)
             self.assertEqual(
                 instruction_schedule_map.get("measure", q).instructions[0][1].duration,
                 custom_meas_duration,

--- a/test/dynamics/backend/test_dynamics_backend.py
+++ b/test/dynamics/backend/test_dynamics_backend.py
@@ -662,8 +662,6 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
                                           (3, 4): [ControlChannel(6)],
                                           (4, 3): [ControlChannel(7)]
                                           }
-        configuration.coupling_map = [[0, 1], [1, 0], [1, 2], [2, 1],
-                                      [1, 3], [3, 1], [3, 4], [4, 3]]
 
         defaults = SimpleNamespace()
         defaults.qubit_freq_est = [
@@ -878,7 +876,7 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
 
     def test_setting_control_channel_map(self):
         """Test if control_channel_map argument is correctly set in the DynamicsBackend options from the original
-        backend control_channel_map (or coupling_map)"""
+        backend control_channel_map"""
 
         # Check that manual setting of the map overrides the one from original backend
         control_channel_map = {(0, 1): 4                                  }
@@ -897,6 +895,7 @@ class TestDynamicsBackend_from_backend(QiskitDynamicsTestCase):
         backend = DynamicsBackend.from_backend(self.valid_backend, subsystem_list=[0, 1, 2])
         assert backend.options.control_channel_map == {(0, 1): 0, (1, 0): 1,
                                                        (1, 2): 2, (2, 1): 3,
+                                                       (1, 3): 4
                                                        }
 
         # Check that manually setting the option after the declaration overwrites the previous map


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

An indent was added in the reference code to avoid faulty behaviours when measurement_properties was added to the DynamicsBackend for the simulation to run properly. The bug was in the fact that the measurement schedule would be added, even though it had not been initialized properly (because the initialization was in a if statement with no else). Another check with a bool test was implemented to avoid loading an empty dictionary in case no measurement_properties was to be added. 

### Details and comments

Minor correction to an emerging bug
