### PR TITLE
Temporary upper bound on JAX version <=0.4.6

### DIFF
--- a/docs/tutorials/dynamics_backend.rst
+++ b/docs/tutorials/dynamics_backend.rst
@@ -473,11 +473,6 @@ values for the single qubit gates calibrated above.
 
     from qiskit_experiments.library import CrossResonanceHamiltonian
 
-    backend.target.add_instruction(
-        instruction=CrossResonanceHamiltonian.CRPulseGate(width=Parameter("width")), 
-        properties={(0, 1): None, (1, 0): None}
-    )
-
     cr_ham_experiment = CrossResonanceHamiltonian(
         qubits=(0, 1), 
         flat_top_widths=np.linspace(0, 5000, 17), 

--- a/docs/tutorials/dynamics_backend.rst
+++ b/docs/tutorials/dynamics_backend.rst
@@ -318,8 +318,9 @@ To enable running of the single qubit experiments, we add the following to the `
   backend. 
 - Add definitions of ``RZ`` gates as phase shifts. These instructions control the phase of the drive
   channels, as well as any control channels acting on a given qubit.
-- Add a ``CX`` gate which applies to all qubits. While this tutorial will not be utilizing it, this
-  ensures that validation steps checking that the device is fully connected will pass.
+- Add a ``CX`` gate between qubits :math:`(0, 1)` and :math:`(1, 0)`. While this tutorial will not 
+  be utilizing it, this ensures that validation steps checking that the device is fully connected 
+  will pass.
 
 .. jupyter-execute::
 
@@ -336,7 +337,7 @@ To enable running of the single qubit experiments, we add the following to the `
     target.add_instruction(XGate(), properties={(0,): None, (1,): None})
     target.add_instruction(SXGate(), properties={(0,): None, (1,): None})
 
-    target.add_instruction(CXGate())
+    target.add_instruction(CXGate(), properties={(0, 1): None, (1, 0): None})
     
     # Add RZ instruction as phase shift for drag cal
     phi = Parameter("phi")

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ requirements = [
     "multiset>=3.0.1",
 ]
 
-jax_extras = ['jax>=0.2.26',
-              'jaxlib>=0.1.75']
+jax_extras = ['jax>=0.2.26, <= 0.4.6',
+              'jaxlib>=0.1.75, <= 0.4.6']
 
 PACKAGES = setuptools.find_packages(exclude=['test*'])
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,15 +15,15 @@ commands = stestr run {posargs}
 [testenv:jax]
 deps =
     -r{toxinidir}/requirements-dev.txt
-    jax
-    jaxlib
+    jax<=0.4.6
+    jaxlib<=0.4.6
     diffrax
 
 [testenv:lint]
 deps =
     -r{toxinidir}/requirements-dev.txt
-    jax
-    jaxlib
+    jax<=0.4.6
+    jaxlib<=0.4.6
     diffrax
 commands =
   black --check {posargs} qiskit_dynamics test
@@ -37,8 +37,8 @@ commands = black {posargs} qiskit_dynamics test
 [testenv:docs]
 deps =
     -r{toxinidir}/requirements-dev.txt
-    jax
-    jaxlib
+    jax<=0.4.6
+    jaxlib<=0.4.6
     diffrax
 commands =
   sphinx-build -b html -W {posargs} docs/ docs/_build/html


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #205.

JAX 0.4.4 introduced a bug that was caught by a Dynamics test ([discussed here](https://github.com/google/jax/discussions/14561)). This was temporarily fixed by #189 , which bypassed the new code. As of JAX 0.4.7, this bypass can no longer be used. This PR sets the upper bound to 0.4.6, the latest version that the bypass works.

To get the tests functioning, this PR also includes corrections to the `DynamicsBackend` tutorial. 

### Details and comments


