### PR TITLE
Bump Sphinx Theme to 1.11

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,8 @@ extensions = [
     'reno.sphinxext',
     'sphinx.ext.intersphinx',
     'nbsphinx',
-    'sphinxcontrib.bibtex'
+    'sphinxcontrib.bibtex',
+    "sphinxcontrib.jquery",  # Remove when changing html_theme to qiskit_ecosystem.
 ]
 templates_path = ["_templates"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ stestr>=3.0.0
 astroid==2.9.3
 pylint==2.12.2
 black~=22.0
-qiskit-sphinx-theme~=1.10
+qiskit-sphinx-theme~=1.11
 sphinx-autodoc-typehints
 jupyter-sphinx
 pygments>=2.4

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,8 @@ commands = black {posargs} qiskit_dynamics test
 
 
 [testenv:docs]
+# Editable mode breaks macOS: https://github.com/sphinx-doc/sphinx/issues/10943
+usedevelop = False
 deps =
     -r{toxinidir}/requirements-dev.txt
     jax


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Major changes include:

1. Fixing IBM fonts not loading
2. Fixing jQuery missing and some JavaScript errors
3. Making the right page table of contents sticky when you scroll down the page.

<img width="1650" alt="Screenshot 2023-04-21 at 11 09 30 AM" src="https://user-images.githubusercontent.com/14852634/233695137-0d083f61-cfac-420b-b815-95fd7066924e.png">


### Details and comments

This also fixes `pyproject.toml` to add the missing `build-backend` key. And it removes `wheel` from what is required, since you don't actually need that.

Finally, it fixes `tox -e docs` not working on macOS by setting `usedevelop = False` like we had to do in Terra.
