### PR TITLE
Bounding Ipython<8.13.0 as it does not support python 3.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ matplotlib>=3.3.0
 qiskit-experiments
 pandas # for docs only
 pylatexenc>=1.4 # for docs only
+ipython<8.13.0 # for docs build with python 3.8


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Ipython 8.13.0 doesn't support python 3.8, causing a docs build error.
