### PR TITLE
Update deploy_documentation.sh to deploy in ecosystem

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2019.
+# (C) Copyright IBM 2018, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# Script for pushing the documentation to the qiskit.org repository.
+# Script for pushing the documentation to the qiskit.org/ecosystem.
 set -e
 
 curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb
@@ -26,7 +26,10 @@ tox -edocs
 echo "show current dir: "
 pwd
 
-# Push to qiskit.org website
+# Push to qiskit.org/ecosystem
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
-echo "Pushing built docs to website"
+echo "Pushing built docs to qiskit.org/ecosystem"
+rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/ecosystem/dynamics
+
+# Push to qiskit.org/documentation
 rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/dynamics


### PR DESCRIPTION
See https://github.com/Qiskit/qiskit.org/issues/3038 for more context

### Summary

The Qiskit Ecosystem lives in qiskit.org/ecosystem and new place for Qiskit related projects that are not technically Qiskit. This PR adds that destination for documentation deployment.

### Details and comments

For now, a copy of the same docs in ecosystem would allow to have both q.o/documentation and q.o/ecosystem for testing that everything is fine. Once that's done, the CDN will redirects to the new location and the deploy to q.o/documentation can be removed.