### PR TITLE
Bound Diffrax version

### DIFF
--- a/releasenotes/notes/diffrax-bound-0bd80c01b7f4b48f.yaml
+++ b/releasenotes/notes/diffrax-bound-0bd80c01b7f4b48f.yaml
@@ -1,0 +1,6 @@
+---
+issues:
+  - |
+    Due to a bug in JAX, Dynamics can only be used with versions of jax and jaxlib <=0.4.6. As they
+    depends on newer versions of JAX, Dynamics is also now only compatible with diffrax<=0.3.1 and
+    equinox<=0.10.3.

--- a/releasenotes/notes/diffrax-bound-0bd80c01b7f4b48f.yaml
+++ b/releasenotes/notes/diffrax-bound-0bd80c01b7f4b48f.yaml
@@ -1,6 +1,5 @@
 ---
 issues:
   - |
-    Due to a bug in JAX, Dynamics can only be used with versions of jax and jaxlib <=0.4.6. As they
-    depends on newer versions of JAX, Dynamics is also now only compatible with diffrax<=0.3.1 and
-    equinox<=0.10.3.
+    Due to a bug in JAX, Dynamics can only be used with jax<=0.4.6. As they depend on newer versions
+    of JAX, Dynamics is also now only compatible with diffrax<=0.3.1 and equinox<=0.10.3.

--- a/tox.ini
+++ b/tox.ini
@@ -17,14 +17,16 @@ deps =
     -r{toxinidir}/requirements-dev.txt
     jax<=0.4.6
     jaxlib<=0.4.6
-    diffrax
+    equinox<=0.10.3
+    diffrax<=0.3.1
 
 [testenv:lint]
 deps =
     -r{toxinidir}/requirements-dev.txt
     jax<=0.4.6
     jaxlib<=0.4.6
-    diffrax
+    equinox<=0.10.3
+    diffrax<=0.3.1
 commands =
   black --check {posargs} qiskit_dynamics test
   pylint -rn -j 0 --rcfile={toxinidir}/.pylintrc qiskit_dynamics/ test/


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The tests were broken due to an update to `diffrax`, which requires the latest version of JAX. As we are currently stuck with an older version of JAX (see #190) this led to an error when importing `diffrax` in the tests. 

This PR bounds both `diffrax` and one of its dependency packages to versions that work with the max allowable version of JAX/jaxlib. It also includes a release note stating what the max allowable versions are for all of these packages.

I'll update #190 with this new jax-related versioning problem. 

### Details and comments


